### PR TITLE
Timestamped state ring + bi-follower aligned-observation assembly + haptic side-channel

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -1,0 +1,124 @@
+cmake_minimum_required(VERSION 3.17)
+project(trlc_dk1_rt LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# --- Find Python and nanobind ---
+find_package(Python 3.12 COMPONENTS Interpreter Development.Module REQUIRED)
+
+# Try to find nanobind via CMake (pip-installed)
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE NB_DIR)
+list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
+find_package(nanobind CONFIG REQUIRED)
+
+# --- Find MuJoCo ---
+# The pip-installed mujoco package provides headers and libraries.
+# We find them via the mujoco Python package path.
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -c "import mujoco; import os; print(os.path.dirname(mujoco.__file__))"
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE MUJOCO_PKG_DIR
+    RESULT_VARIABLE MUJOCO_RESULT)
+
+if(MUJOCO_RESULT EQUAL 0 AND EXISTS "${MUJOCO_PKG_DIR}")
+    # Headers are typically in the package directory or a subdirectory
+    find_path(MUJOCO_INCLUDE_DIR mujoco/mujoco.h
+        HINTS "${MUJOCO_PKG_DIR}/include" "${MUJOCO_PKG_DIR}"
+              "${MUJOCO_PKG_DIR}/../mujoco.libs/../include"
+        NO_DEFAULT_PATH)
+
+    # Also check system paths
+    if(NOT MUJOCO_INCLUDE_DIR)
+        find_path(MUJOCO_INCLUDE_DIR mujoco/mujoco.h)
+    endif()
+
+    # Find the shared library
+    find_library(MUJOCO_LIBRARY
+        NAMES mujoco
+        HINTS "${MUJOCO_PKG_DIR}" "${MUJOCO_PKG_DIR}/../mujoco.libs"
+              "${MUJOCO_PKG_DIR}/lib"
+        NO_DEFAULT_PATH)
+
+    if(NOT MUJOCO_LIBRARY)
+        # Look for the shared library in the package directory
+        # Linux: libmujoco.so.X.Y.Z in mujoco/ or mujoco.libs/
+        # macOS: libmujoco.X.Y.Z.dylib in mujoco/
+        file(GLOB MUJOCO_LIBRARY_GLOB "${MUJOCO_PKG_DIR}/libmujoco*.so*"
+                                       "${MUJOCO_PKG_DIR}/libmujoco*.dylib"
+                                       "${MUJOCO_PKG_DIR}/../mujoco.libs/libmujoco*.so*")
+        if(MUJOCO_LIBRARY_GLOB)
+            list(GET MUJOCO_LIBRARY_GLOB 0 MUJOCO_LIBRARY)
+        endif()
+    endif()
+
+    if(NOT MUJOCO_LIBRARY)
+        find_library(MUJOCO_LIBRARY NAMES mujoco)
+    endif()
+
+    if(MUJOCO_INCLUDE_DIR AND MUJOCO_LIBRARY)
+        message(STATUS "MuJoCo include: ${MUJOCO_INCLUDE_DIR}")
+        message(STATUS "MuJoCo library: ${MUJOCO_LIBRARY}")
+    else()
+        message(WARNING "MuJoCo headers or library not found. Include: ${MUJOCO_INCLUDE_DIR}, Lib: ${MUJOCO_LIBRARY}")
+    endif()
+else()
+    message(WARNING "mujoco Python package not found, trying system paths")
+    find_path(MUJOCO_INCLUDE_DIR mujoco/mujoco.h)
+    find_library(MUJOCO_LIBRARY NAMES mujoco)
+endif()
+
+# --- Build extension module ---
+nanobind_add_module(_trlc_dk1_rt
+    bindings.cpp
+    serial_port.cpp
+    rt_utils.cpp
+    gravity_comp.cpp
+    control_loop.cpp
+)
+
+target_include_directories(_trlc_dk1_rt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# MuJoCo
+if(MUJOCO_INCLUDE_DIR)
+    target_include_directories(_trlc_dk1_rt PRIVATE ${MUJOCO_INCLUDE_DIR})
+endif()
+if(MUJOCO_LIBRARY)
+    target_link_libraries(_trlc_dk1_rt PRIVATE ${MUJOCO_LIBRARY})
+endif()
+
+# pthreads
+find_package(Threads REQUIRED)
+target_link_libraries(_trlc_dk1_rt PRIVATE Threads::Threads)
+
+# Set RPATH so the extension can find libmujoco in the mujoco sibling package
+if(APPLE)
+    set_target_properties(_trlc_dk1_rt PROPERTIES
+        INSTALL_RPATH "@loader_path/../mujoco"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+else()
+    set_target_properties(_trlc_dk1_rt PROPERTIES
+        INSTALL_RPATH "$ORIGIN/../mujoco"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+endif()
+
+# Install the module into the Python package
+install(TARGETS _trlc_dk1_rt LIBRARY DESTINATION trlc_dk1_control)
+
+# --- Unit tests (optional) ---
+option(BUILD_TESTS "Build C++ unit tests" OFF)
+if(BUILD_TESTS)
+    enable_testing()
+
+    add_executable(test_dm_protocol tests/test_dm_protocol.cpp)
+    target_include_directories(test_dm_protocol PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    add_test(NAME test_dm_protocol COMMAND test_dm_protocol)
+
+    add_executable(test_perf_counters tests/test_perf_counters.cpp)
+    target_include_directories(test_perf_counters PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(test_perf_counters PRIVATE Threads::Threads)
+    add_test(NAME test_perf_counters COMMAND test_perf_counters)
+endif()

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -154,7 +154,7 @@ NB_MODULE(_trlc_dk1_rt, m) {
         .def_ro("pos", &GripperState::pos)
         .def_ro("torque", &GripperState::torque);
 
-    // TimedJointSnapshot — used by get_state_at() for Option C alignment.
+    // TimedJointSnapshot — returned by get_state_at() for time-aligned reads.
     nb::class_<TimedJointSnapshot>(m, "TimedJointSnapshot")
         .def_ro("ts_mono_ns", &TimedJointSnapshot::ts_mono_ns)
         .def_ro("joints", &TimedJointSnapshot::joints)

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -1,0 +1,211 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/array.h>
+#include <nanobind/ndarray.h>
+
+#include "control_loop.h"
+#include "rt_utils.h"
+
+namespace nb = nanobind;
+using namespace trlc;
+
+NB_MODULE(_trlc_dk1_rt, m) {
+    m.doc() = "TRLC-DK1 real-time control loop (C++ with nanobind)";
+
+    // MotorType enum
+    nb::enum_<MotorType>(m, "MotorType")
+        .value("DM4310", MotorType::DM4310)
+        .value("DM4310_48V", MotorType::DM4310_48V)
+        .value("DM4340", MotorType::DM4340)
+        .value("DM4340_48V", MotorType::DM4340_48V)
+        .value("DM6006", MotorType::DM6006)
+        .value("DM8006", MotorType::DM8006)
+        .value("DM8009", MotorType::DM8009)
+        .value("DM10010L", MotorType::DM10010L)
+        .value("DM10010", MotorType::DM10010)
+        .value("DMH3510", MotorType::DMH3510)
+        .value("DMH6215", MotorType::DMH6215)
+        .value("DMG6220", MotorType::DMG6220);
+
+    // CommLossAction enum
+    nb::enum_<CommLossAction>(m, "CommLossAction")
+        .value("HOLD", CommLossAction::HOLD)
+        .value("DISABLE", CommLossAction::DISABLE);
+
+    // MotorDescriptor
+    nb::class_<MotorDescriptor>(m, "MotorDescriptor")
+        .def(nb::init<>())
+        .def_rw("name", &MotorDescriptor::name)
+        .def_rw("type", &MotorDescriptor::type)
+        .def_rw("slave_id", &MotorDescriptor::slave_id)
+        .def_rw("master_id", &MotorDescriptor::master_id);
+
+    // PerfSnapshot
+    nb::class_<PerfSnapshot>(m, "PerfSnapshot")
+        .def(nb::init<>())
+        .def_ro("loop_count", &PerfSnapshot::loop_count)
+        .def_ro("min_cycle_us", &PerfSnapshot::min_cycle_us)
+        .def_ro("max_cycle_us", &PerfSnapshot::max_cycle_us)
+        .def_ro("mean_cycle_us", &PerfSnapshot::mean_cycle_us)
+        .def_ro("deadline_misses", &PerfSnapshot::deadline_misses)
+        .def_prop_ro("histogram", [](const PerfSnapshot& s) {
+            return nb::ndarray<nb::numpy, const uint64_t, nb::shape<6>>(
+                s.histogram.data(), {6});
+        });
+
+    // RtLoopConfig
+    nb::class_<RtLoopConfig>(m, "RtLoopConfig")
+        .def(nb::init<>())
+        .def_rw("serial_port", &RtLoopConfig::serial_port)
+        .def_rw("loop_hz", &RtLoopConfig::loop_hz)
+        .def_rw("motors", &RtLoopConfig::motors)
+        .def_rw("limit_buffer", &RtLoopConfig::limit_buffer)
+        .def_rw("model_path", &RtLoopConfig::model_path)
+        .def_rw("gravity_comp_scale", &RtLoopConfig::gravity_comp_scale)
+        .def_rw("command_timeout_s", &RtLoopConfig::command_timeout_s)
+        .def_rw("overcurrent_threshold", &RtLoopConfig::overcurrent_threshold)
+        .def_rw("overspeed_threshold", &RtLoopConfig::overspeed_threshold)
+        .def_rw("min_motors_required", &RtLoopConfig::min_motors_required)
+        .def_rw("gripper_open_pos", &RtLoopConfig::gripper_open_pos)
+        .def_rw("gripper_closed_pos", &RtLoopConfig::gripper_closed_pos)
+        .def_rw("max_gripper_torque_nm", &RtLoopConfig::max_gripper_torque_nm)
+        .def_rw("torque_constant", &RtLoopConfig::torque_constant)
+        .def_rw("emit_velocity_scale", &RtLoopConfig::emit_velocity_scale)
+        .def_rw("emit_current_scale", &RtLoopConfig::emit_current_scale)
+        .def_rw("gripper_cal_timeout_s", &RtLoopConfig::gripper_cal_timeout_s)
+        .def_rw("disable_torque_on_disconnect", &RtLoopConfig::disable_torque_on_disconnect)
+        .def_rw("rt_priority", &RtLoopConfig::rt_priority)
+        .def_rw("rt_cpu_affinity", &RtLoopConfig::rt_cpu_affinity)
+        .def_rw("rt_use_mlockall", &RtLoopConfig::rt_use_mlockall)
+        .def_rw("max_consecutive_empty_cycles", &RtLoopConfig::max_consecutive_empty_cycles)
+        .def_rw("comm_loss_action", &RtLoopConfig::comm_loss_action)
+        .def_rw("per_motor_stale_threshold", &RtLoopConfig::per_motor_stale_threshold)
+        // std::array properties exposed via lambdas for numpy compatibility
+        .def_prop_rw("default_kp",
+            [](const RtLoopConfig& c) {
+                return nb::ndarray<nb::numpy, const double, nb::shape<6>>(
+                    c.default_kp.data(), {6});
+            },
+            [](RtLoopConfig& c, nb::ndarray<nb::numpy, const double, nb::shape<6>> arr) {
+                const double* p = arr.data();
+                for (int i = 0; i < 6; ++i) c.default_kp[static_cast<size_t>(i)] = p[i];
+            })
+        .def_prop_rw("default_kd",
+            [](const RtLoopConfig& c) {
+                return nb::ndarray<nb::numpy, const double, nb::shape<6>>(
+                    c.default_kd.data(), {6});
+            },
+            [](RtLoopConfig& c, nb::ndarray<nb::numpy, const double, nb::shape<6>> arr) {
+                const double* p = arr.data();
+                for (int i = 0; i < 6; ++i) c.default_kd[static_cast<size_t>(i)] = p[i];
+            })
+        .def_prop_rw("joint_pos_limits",
+            [](const RtLoopConfig& c) {
+                return nb::ndarray<nb::numpy, const double, nb::shape<12>>(
+                    c.joint_pos_limits.data(), {12});
+            },
+            [](RtLoopConfig& c, nb::ndarray<nb::numpy, const double, nb::shape<12>> arr) {
+                const double* p = arr.data();
+                for (int i = 0; i < 12; ++i) c.joint_pos_limits[static_cast<size_t>(i)] = p[i];
+            })
+        .def_prop_rw("joint_torque_limits",
+            [](const RtLoopConfig& c) {
+                return nb::ndarray<nb::numpy, const double, nb::shape<6>>(
+                    c.joint_torque_limits.data(), {6});
+            },
+            [](RtLoopConfig& c, nb::ndarray<nb::numpy, const double, nb::shape<6>> arr) {
+                const double* p = arr.data();
+                for (int i = 0; i < 6; ++i) c.joint_torque_limits[static_cast<size_t>(i)] = p[i];
+            })
+        .def_prop_rw("joint_velocity_limits",
+            [](const RtLoopConfig& c) {
+                return nb::ndarray<nb::numpy, const double, nb::shape<6>>(
+                    c.joint_velocity_limits.data(), {6});
+            },
+            [](RtLoopConfig& c, nb::ndarray<nb::numpy, const double, nb::shape<6>> arr) {
+                const double* p = arr.data();
+                for (int i = 0; i < 6; ++i) c.joint_velocity_limits[static_cast<size_t>(i)] = p[i];
+            })
+        .def_prop_rw("max_pos_delta_per_cycle",
+            [](const RtLoopConfig& c) {
+                return nb::ndarray<nb::numpy, const double, nb::shape<6>>(
+                    c.max_pos_delta_per_cycle.data(), {6});
+            },
+            [](RtLoopConfig& c, nb::ndarray<nb::numpy, const double, nb::shape<6>> arr) {
+                const double* p = arr.data();
+                for (int i = 0; i < 6; ++i) c.max_pos_delta_per_cycle[static_cast<size_t>(i)] = p[i];
+            });
+
+    // JointState
+    nb::class_<JointState>(m, "JointState")
+        .def_prop_ro("pos", [](const JointState& s) {
+            return nb::ndarray<nb::numpy, const double, nb::shape<6>>(s.pos.data(), {6});
+        })
+        .def_prop_ro("vel", [](const JointState& s) {
+            return nb::ndarray<nb::numpy, const double, nb::shape<6>>(s.vel.data(), {6});
+        })
+        .def_prop_ro("torque", [](const JointState& s) {
+            return nb::ndarray<nb::numpy, const double, nb::shape<6>>(s.torque.data(), {6});
+        });
+
+    // GripperState
+    nb::class_<GripperState>(m, "GripperState")
+        .def_ro("pos", &GripperState::pos)
+        .def_ro("torque", &GripperState::torque);
+
+    // HealthState
+    nb::class_<HealthState>(m, "HealthState")
+        .def(nb::init<>())
+        .def_ro("damping_mode", &HealthState::damping_mode)
+        .def_ro("overcurrent_count", &HealthState::overcurrent_count)
+        .def_ro("overspeed_count", &HealthState::overspeed_count)
+        .def_ro("comm_loss", &HealthState::comm_loss)
+        .def_ro("consecutive_empty_cycles", &HealthState::consecutive_empty_cycles)
+        .def_ro("total_rx_bytes", &HealthState::total_rx_bytes)
+        .def_ro("total_tx_frames", &HealthState::total_tx_frames)
+        .def_ro("total_write_errors", &HealthState::total_write_errors)
+        .def_ro("loop_count", &HealthState::loop_count)
+        .def_prop_ro("motor_last_seen_cycle", [](const HealthState& h) {
+            return nb::ndarray<nb::numpy, const uint64_t, nb::shape<7>>(
+                h.motor_last_seen_cycle.data(), {7});
+        })
+        .def_prop_ro("motor_stale", [](const HealthState& h) {
+            nb::list result;
+            for (int i = 0; i < 7; ++i) result.append(h.motor_stale[i]);
+            return result;
+        });
+
+    // RtControlLoop
+    nb::class_<RtControlLoop>(m, "RtControlLoop")
+        .def(nb::init<const RtLoopConfig&>())
+        .def("start", &RtControlLoop::start)
+        .def("stop", &RtControlLoop::stop)
+        .def("command_joint_pos", [](RtControlLoop& loop,
+                nb::ndarray<nb::numpy, const double, nb::shape<6>> q) {
+            loop.command_joint_pos(q.data());
+        })
+        .def("command_gripper", &RtControlLoop::command_gripper)
+        .def("get_joint_state", &RtControlLoop::get_joint_state)
+        .def("get_gripper_state", &RtControlLoop::get_gripper_state)
+        .def("get_health", &RtControlLoop::get_health)
+        .def("reset_errors", &RtControlLoop::reset_errors, nb::arg("timeout_ms") = 100)
+        .def("get_perf", &RtControlLoop::get_perf)
+        .def("read_cycle_times", [](const RtControlLoop& loop, size_t max_count) {
+            std::vector<float> buf(max_count);
+            size_t n = loop.read_cycle_times(buf.data(), max_count);
+            buf.resize(n);
+            // Return as numpy array
+            auto* data = new float[n];
+            std::copy(buf.begin(), buf.end(), data);
+            nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<float*>(p); });
+            return nb::ndarray<nb::numpy, float>(data, {n}, owner);
+        })
+        .def("reset_perf", &RtControlLoop::reset_perf, nb::arg("timeout_ms") = 100)
+        .def("is_running", &RtControlLoop::is_running)
+        .def("is_rt_active", &RtControlLoop::is_rt_active);
+
+    // Free functions
+    m.def("detect_rt_kernel", &detect_rt_kernel,
+          "Check if running on a PREEMPT_RT kernel");
+}

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -154,6 +154,12 @@ NB_MODULE(_trlc_dk1_rt, m) {
         .def_ro("pos", &GripperState::pos)
         .def_ro("torque", &GripperState::torque);
 
+    // TimedJointSnapshot — used by get_state_at() for Option C alignment.
+    nb::class_<TimedJointSnapshot>(m, "TimedJointSnapshot")
+        .def_ro("ts_mono_ns", &TimedJointSnapshot::ts_mono_ns)
+        .def_ro("joints", &TimedJointSnapshot::joints)
+        .def_ro("gripper", &TimedJointSnapshot::gripper);
+
     // HealthState
     nb::class_<HealthState>(m, "HealthState")
         .def(nb::init<>())
@@ -188,6 +194,18 @@ NB_MODULE(_trlc_dk1_rt, m) {
         .def("command_gripper", &RtControlLoop::command_gripper)
         .def("get_joint_state", &RtControlLoop::get_joint_state)
         .def("get_gripper_state", &RtControlLoop::get_gripper_state)
+        .def("get_state_at",
+             [](const RtControlLoop& loop, uint64_t ts_ns) -> nb::object {
+                 TimedJointSnapshot snap;
+                 if (!loop.get_state_at(ts_ns, snap)) {
+                     return nb::none();
+                 }
+                 return nb::cast(snap);
+             },
+             nb::arg("ts_ns"),
+             "Return a TimedJointSnapshot (joints + gripper) whose ts_mono_ns "
+             "is the latest sample at-or-before the requested time; None if no "
+             "such sample is available in the ~1s ring of recent state.")
         .def("get_health", &RtControlLoop::get_health)
         .def("reset_errors", &RtControlLoop::reset_errors, nb::arg("timeout_ms") = 100)
         .def("get_perf", &RtControlLoop::get_perf)

--- a/csrc/control_loop.cpp
+++ b/csrc/control_loop.cpp
@@ -196,6 +196,61 @@ GripperState RtControlLoop::get_gripper_state() const {
     return result;
 }
 
+bool RtControlLoop::get_state_at(uint64_t ts_ns, TimedJointSnapshot& out) const {
+    // Lock-free, single-producer / multi-consumer ring read.
+    //
+    // The RT thread (producer) writes a slot and then release-stores the new
+    // write_idx. Readers acquire-load write_idx, scan slots from newest to
+    // oldest looking for one with ts_mono_ns <= ts_ns, copy out, then re-load
+    // write_idx to verify the slot they read wasn't overwritten between the
+    // first load and the copy. If the slot was lapped (new_idx - found_idx
+    // > STATE_RING_SIZE), retry up to a few times.
+    constexpr int MAX_ATTEMPTS = 4;
+    for (int attempt = 0; attempt < MAX_ATTEMPTS; ++attempt) {
+        const uint64_t idx = state_ring_write_idx_.load(std::memory_order_acquire);
+        if (idx == 0) return false;
+        const size_t scan = std::min<size_t>(STATE_RING_SIZE, idx);
+        size_t found_slot = 0;
+        uint64_t found_slot_idx = 0;
+        bool found = false;
+        for (size_t i = 0; i < scan; ++i) {
+            const uint64_t slot_idx = idx - 1 - i;
+            const RingSlot& s = state_ring_[slot_idx % STATE_RING_SIZE];
+            if (s.ts_mono_ns <= ts_ns) {
+                out.ts_mono_ns = s.ts_mono_ns;
+                for (int j = 0; j < 6; ++j) {
+                    out.joints.pos[static_cast<size_t>(j)] = s.pos[static_cast<size_t>(j)];
+                    out.joints.vel[static_cast<size_t>(j)] = s.vel[static_cast<size_t>(j)];
+                    out.joints.torque[static_cast<size_t>(j)] = s.torque[static_cast<size_t>(j)];
+                }
+                // Gripper: normalize to [0, 1] like get_gripper_state() does,
+                // for consistency with the legacy "latest" API.
+                double gpos = s.pos[6];
+                const double range = cfg_.gripper_closed_pos - gripper_open_pos_;
+                if (std::abs(range) > 1e-6) {
+                    gpos = std::clamp((gpos - gripper_open_pos_) / range, 0.0, 1.0);
+                }
+                out.gripper.pos = gpos;
+                out.gripper.torque = s.torque[6];
+                found_slot = slot_idx % STATE_RING_SIZE;
+                (void)found_slot;
+                found_slot_idx = slot_idx;
+                found = true;
+                break;
+            }
+        }
+        if (!found) return false;
+
+        // Verify the slot we copied wasn't overwritten while we were reading it.
+        const uint64_t new_idx = state_ring_write_idx_.load(std::memory_order_acquire);
+        if (new_idx - found_slot_idx <= STATE_RING_SIZE) {
+            return true;  // slot still in-ring
+        }
+        // Otherwise the producer lapped us. Retry.
+    }
+    return false;  // gave up after MAX_ATTEMPTS races
+}
+
 HealthState RtControlLoop::get_health() const {
     HealthState result;
     for (int attempt = 0; attempt < 100; ++attempt) {
@@ -671,6 +726,21 @@ void RtControlLoop::rt_thread_func() {
             state_buf_.vel = cur_vel;
             state_buf_.torque = cur_torque;
             state_seq_.store(s + 2, std::memory_order_release);
+        }
+
+        // 3b. Also push to the timestamped ring (Option C alignment). Single
+        //     producer (this RT thread), multiple readers (Python).
+        //     The release-store of write_idx makes the slot's fields visible
+        //     to any reader that observes the new index; readers verify they
+        //     weren't lapped by re-reading write_idx after copying the slot.
+        {
+            const uint64_t idx = state_ring_write_idx_.load(std::memory_order_relaxed);
+            RingSlot& r = state_ring_[idx % STATE_RING_SIZE];
+            r.ts_mono_ns = now_ns();
+            r.pos = cur_pos;
+            r.vel = cur_vel;
+            r.torque = cur_torque;
+            state_ring_write_idx_.store(idx + 1, std::memory_order_release);
         }
 
         // Publish health state (seqlock)

--- a/csrc/control_loop.cpp
+++ b/csrc/control_loop.cpp
@@ -728,8 +728,8 @@ void RtControlLoop::rt_thread_func() {
             state_seq_.store(s + 2, std::memory_order_release);
         }
 
-        // 3b. Also push to the timestamped ring (Option C alignment). Single
-        //     producer (this RT thread), multiple readers (Python).
+        // 3b. Also push to the timestamped state ring (used by get_state_at).
+        //     Single producer (this RT thread), multiple readers (Python).
         //     The release-store of write_idx makes the slot's fields visible
         //     to any reader that observes the new index; readers verify they
         //     weren't lapped by re-reading write_idx after copying the slot.

--- a/csrc/control_loop.cpp
+++ b/csrc/control_loop.cpp
@@ -1,0 +1,895 @@
+#include "control_loop.h"
+#include "rt_utils.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <chrono>
+#include <sstream>
+#include <stdexcept>
+#include <time.h>
+
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#endif
+
+namespace trlc {
+
+static uint64_t now_ns() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL + static_cast<uint64_t>(ts.tv_nsec);
+}
+
+static void sleep_until_ns(uint64_t target_ns) {
+#ifdef __APPLE__
+    // macOS lacks clock_nanosleep; use mach_wait_until for absolute sleep
+    static mach_timebase_info_data_t tb = {};
+    if (tb.denom == 0) mach_timebase_info(&tb);
+    // Convert wall-clock ns to mach absolute time units
+    uint64_t mach_target = target_ns * tb.denom / tb.numer;
+    mach_wait_until(mach_target);
+#else
+    struct timespec ts;
+    ts.tv_sec = static_cast<time_t>(target_ns / 1000000000ULL);
+    ts.tv_nsec = static_cast<long>(target_ns % 1000000000ULL);
+    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, nullptr);
+#endif
+}
+
+static void sleep_ms(int ms) {
+    struct timespec ts = {ms / 1000, (ms % 1000) * 1000000};
+    nanosleep(&ts, nullptr);
+}
+
+// Write a frame then wait for and read the response.
+static size_t send_and_recv(SerialPort& serial, const uint8_t* tx, size_t tx_len,
+                            uint8_t* rx_buf, size_t rx_max, int timeout_us = 2000) {
+    serial.write(tx, tx_len);
+    return serial.read_with_timeout(rx_buf, rx_max, timeout_us);
+}
+
+RtControlLoop::RtControlLoop(const RtLoopConfig& cfg) : cfg_(cfg) {}
+
+RtControlLoop::~RtControlLoop() {
+    stop();
+}
+
+void RtControlLoop::start() {
+    if (running_.load()) {
+        throw std::runtime_error("RtControlLoop already running");
+    }
+
+    // Validate configuration
+    if (cfg_.loop_hz <= 0.0 || cfg_.loop_hz > 10000.0) {
+        throw std::invalid_argument("loop_hz must be in (0, 10000], got: " +
+                                    std::to_string(cfg_.loop_hz));
+    }
+    if (cfg_.motors.size() < 7) {
+        throw std::invalid_argument("Need at least 7 motor descriptors (6 arm + 1 gripper), got: " +
+                                    std::to_string(cfg_.motors.size()));
+    }
+    if (cfg_.command_timeout_s <= 0.0) {
+        throw std::invalid_argument("command_timeout_s must be positive, got: " +
+                                    std::to_string(cfg_.command_timeout_s));
+    }
+    if (cfg_.min_motors_required < 0 || cfg_.min_motors_required > 6) {
+        throw std::invalid_argument("min_motors_required must be in [0, 6], got: " +
+                                    std::to_string(cfg_.min_motors_required));
+    }
+
+    if (!serial_.open(cfg_.serial_port, 921600)) {
+        throw std::runtime_error("Failed to open serial port: " + cfg_.serial_port);
+    }
+
+    sleep_ms(500);
+    configure_motors();
+
+    if (!cfg_.model_path.empty()) {
+        if (!grav_comp_.load(cfg_.model_path, 6)) {
+            std::fprintf(stderr, "Warning: gravity compensation disabled (failed to load model)\n");
+        }
+    }
+
+    calibrate_gripper();
+
+    // Initialize command buffer to current position
+    {
+        uint64_t s = cmd_seq_.load(std::memory_order_relaxed);
+        cmd_seq_.store(s + 1, std::memory_order_release);
+        for (int i = 0; i < 6; ++i) {
+            cmd_buf_.q_des[static_cast<size_t>(i)] = state_buf_.pos[static_cast<size_t>(i)];
+        }
+        cmd_buf_.gripper_des = 0.0;
+        cmd_buf_.timestamp_ns = now_ns();
+        cmd_seq_.store(s + 2, std::memory_order_release);
+    }
+
+    std::fprintf(stderr, "Command buffer initialized to current pos:\n");
+    for (int i = 0; i < 6; ++i) {
+        std::fprintf(stderr, "  joint[%d] q_des=%.4f (from state_buf_.pos=%.4f)\n",
+                     i, cmd_buf_.q_des[static_cast<size_t>(i)],
+                     state_buf_.pos[static_cast<size_t>(i)]);
+    }
+
+    running_.store(true, std::memory_order_release);
+    thread_ = std::thread(&RtControlLoop::rt_thread_func, this);
+}
+
+void RtControlLoop::stop() {
+    if (!running_.load()) return;
+    running_.store(false, std::memory_order_release);
+    if (thread_.joinable()) thread_.join();
+
+    uint8_t frame[30];
+    uint8_t rx_buf[256];
+
+    // Drain any pending data from the serial buffer
+    while (serial_.read_all(rx_buf, sizeof(rx_buf)) > 0) {}
+
+    // Disable all motors — send all frames back-to-back without waiting
+    // for individual responses.  The motors will process the disable
+    // commands regardless of whether we read the acks.
+    if (cfg_.disable_torque_on_disconnect) {
+        for (const auto& m : cfg_.motors) {
+            build_disable_frame(frame, m.slave_id);
+            serial_.write(frame, 30);
+        }
+        // Brief pause for the last frame to be transmitted over USB
+        sleep_ms(20);
+    }
+
+    serial_.close();
+    std::fprintf(stderr, "RtControlLoop stopped\n");
+}
+
+void RtControlLoop::command_joint_pos(const double* q6) {
+    uint64_t s = cmd_seq_.load(std::memory_order_relaxed);
+    cmd_seq_.store(s + 1, std::memory_order_release);
+    std::memcpy(cmd_buf_.q_des.data(), q6, 6 * sizeof(double));
+    cmd_buf_.timestamp_ns = now_ns();
+    cmd_seq_.store(s + 2, std::memory_order_release);
+}
+
+void RtControlLoop::command_gripper(double normalized) {
+    normalized = std::clamp(normalized, 0.0, 1.0);
+    uint64_t s = cmd_seq_.load(std::memory_order_relaxed);
+    cmd_seq_.store(s + 1, std::memory_order_release);
+    cmd_buf_.gripper_des = normalized;
+    cmd_buf_.timestamp_ns = now_ns();
+    cmd_seq_.store(s + 2, std::memory_order_release);
+}
+
+JointState RtControlLoop::get_joint_state() const {
+    JointState result;
+    for (int attempt = 0; attempt < 100; ++attempt) {
+        uint64_t s1 = state_seq_.load(std::memory_order_acquire);
+        if (s1 & 1) continue;
+        for (int i = 0; i < 6; ++i) {
+            result.pos[static_cast<size_t>(i)] = state_buf_.pos[static_cast<size_t>(i)];
+            result.vel[static_cast<size_t>(i)] = state_buf_.vel[static_cast<size_t>(i)];
+            result.torque[static_cast<size_t>(i)] = state_buf_.torque[static_cast<size_t>(i)];
+        }
+        uint64_t s2 = state_seq_.load(std::memory_order_acquire);
+        if (s1 == s2) return result;
+    }
+    return result;
+}
+
+GripperState RtControlLoop::get_gripper_state() const {
+    GripperState result;
+    for (int attempt = 0; attempt < 100; ++attempt) {
+        uint64_t s1 = state_seq_.load(std::memory_order_acquire);
+        if (s1 & 1) continue;
+        result.pos = state_buf_.pos[6];
+        result.torque = state_buf_.torque[6];
+        uint64_t s2 = state_seq_.load(std::memory_order_acquire);
+        if (s1 == s2) {
+            double range = cfg_.gripper_closed_pos - gripper_open_pos_;
+            if (std::abs(range) > 1e-6) {
+                result.pos = std::clamp((result.pos - gripper_open_pos_) / range, 0.0, 1.0);
+            }
+            return result;
+        }
+    }
+    return result;
+}
+
+HealthState RtControlLoop::get_health() const {
+    HealthState result;
+    for (int attempt = 0; attempt < 100; ++attempt) {
+        uint64_t s1 = health_seq_.load(std::memory_order_acquire);
+        if (s1 & 1) continue;
+        result = health_buf_;
+        uint64_t s2 = health_seq_.load(std::memory_order_acquire);
+        if (s1 == s2) return result;
+    }
+    return result;  // best effort
+}
+
+void RtControlLoop::reset_errors(int timeout_ms) {
+    if (!running_.load(std::memory_order_acquire)) return;
+    uint64_t before = error_reset_ack_.load(std::memory_order_acquire);
+    error_reset_requested_.store(true, std::memory_order_release);
+    if (timeout_ms <= 0) return;  // fire-and-forget
+    for (int waited = 0; waited < timeout_ms; ++waited) {
+        if (error_reset_ack_.load(std::memory_order_acquire) != before) return;
+        if (!running_.load(std::memory_order_acquire)) return;
+        struct timespec ts = {0, 1000000};  // 1ms
+        nanosleep(&ts, nullptr);
+    }
+    throw std::runtime_error("reset_errors() timed out waiting for RT thread acknowledgment");
+}
+
+PerfSnapshot RtControlLoop::get_perf() const { return perf_.snapshot(); }
+
+size_t RtControlLoop::read_cycle_times(float* buf, size_t max) const {
+    return perf_.read_ring(buf, max);
+}
+
+void RtControlLoop::reset_perf(int timeout_ms) { perf_.reset(timeout_ms); }
+
+// --- Motor configuration ---
+
+void RtControlLoop::configure_motors() {
+    if (cfg_.motors.size() < 7) {
+        throw std::runtime_error("Need at least 7 motor descriptors (6 arm + 1 gripper)");
+    }
+
+    uint8_t frame[30];
+    uint8_t rx_buf[256];
+
+    for (const auto& m : cfg_.motors) {
+        for (int attempt = 0; attempt < 3; ++attempt) {
+            build_refresh_frame(frame, m.slave_id);
+            send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 10000);
+        }
+        std::fprintf(stderr, "%s (slave=%d master=0x%02X) connected\n",
+                     m.name.c_str(), m.slave_id, m.master_id);
+    }
+
+    // Switch arm joints to MIT mode and enable
+    for (size_t i = 0; i < 6; ++i) {
+        const auto& m = cfg_.motors[i];
+        build_switch_mode_frame(frame, m.slave_id, 1);
+        send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 100000);
+        build_enable_frame(frame, m.slave_id);
+        send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 100000);
+    }
+
+    // Drain any leftover bytes from mode-switch / enable responses
+    parser_.clear();
+    sleep_ms(50);
+    while (true) {
+        size_t n = serial_.read_all(rx_buf, sizeof(rx_buf));
+        if (n == 0) break;
+    }
+
+    // Read initial arm state — retry multiple times to ensure we get all 6 motors
+    std::array<bool, 6> got_initial = {};
+    std::array<int, 6> param_resp_count = {};  // track motors stuck returning param responses
+    int total_got = 0;
+
+    for (int round = 0; round < 8 && total_got < 6; ++round) {
+        std::vector<std::array<uint8_t, RX_PACKET_LEN>> packets;
+        for (size_t i = 0; i < 6; ++i) {
+            if (got_initial[i]) continue;
+            const auto& m = cfg_.motors[i];
+
+            // If a motor keeps returning param responses, re-cycle it
+            if (round > 0 && param_resp_count[i] >= 2) {
+                std::fprintf(stderr, "  [init round %d] motor %zu (%s) stuck in param mode — "
+                             "disable/re-enable\n", round, i, m.name.c_str());
+                build_disable_frame(frame, m.slave_id);
+                send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 50000);
+                sleep_ms(50);
+                build_switch_mode_frame(frame, m.slave_id, 1);
+                send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 100000);
+                build_enable_frame(frame, m.slave_id);
+                send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 100000);
+                sleep_ms(50);
+                // Drain residual param ack packets
+                while (serial_.read_all(rx_buf, sizeof(rx_buf)) > 0) {}
+                parser_.clear();
+                param_resp_count[i] = 0;
+            }
+
+            build_refresh_frame(frame, m.slave_id);
+            size_t n = send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 10000);
+            std::fprintf(stderr, "  [init round %d] refresh motor %zu (%s): rx %zu bytes\n",
+                         round, i, m.name.c_str(), n);
+            if (n > 0) {
+                parser_.feed(rx_buf, n);
+                parser_.extract(packets);
+            }
+        }
+
+        for (const auto& pkt : packets) {
+            uint32_t can_id = decode_can_id(pkt.data());
+            uint8_t cmd = decode_cmd(pkt.data());
+            if (cmd != 0x11) {
+                std::fprintf(stderr, "  [init] skip packet can_id=0x%03X cmd=0x%02X (not motor state)\n", can_id, cmd);
+                continue;
+            }
+            if (is_param_response(pkt.data())) {
+                std::fprintf(stderr, "  [init] skip param response can_id=0x%03X\n", can_id);
+                // Track which motor is stuck
+                for (size_t i = 0; i < 6; ++i) {
+                    if (got_initial[i]) continue;
+                    const auto& m = cfg_.motors[i];
+                    if (can_id == m.slave_id || can_id == m.master_id ||
+                        (can_id == 0 && decode_response_id(pkt.data()) == (m.master_id & 0x0F))) {
+                        ++param_resp_count[i];
+                        break;
+                    }
+                }
+                continue;
+            }
+
+            for (size_t i = 0; i < 6; ++i) {
+                if (got_initial[i]) continue;
+                const auto& m = cfg_.motors[i];
+                bool match = (can_id == m.slave_id) ||
+                             (can_id == m.master_id) ||
+                             (can_id == 0 && decode_response_id(pkt.data()) == (m.master_id & 0x0F));
+                if (match) {
+                    auto st = decode_motor_state(pkt.data(), get_limits(m.type));
+                    state_buf_.pos[i] = st.q;
+                    state_buf_.vel[i] = st.dq;
+                    state_buf_.torque[i] = st.tau;
+                    got_initial[i] = true;
+                    ++total_got;
+                    std::fprintf(stderr, "  %s initial pos=%.4f vel=%.4f tau=%.4f (matched can_id=0x%03X)\n",
+                                 m.name.c_str(), st.q, st.dq, st.tau, can_id);
+                    break;
+                }
+            }
+        }
+    }
+
+    if (total_got < cfg_.min_motors_required) {
+        // Disable motors we already enabled before throwing
+        for (size_t i = 0; i < 6; ++i) {
+            build_disable_frame(frame, cfg_.motors[i].slave_id);
+            send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 50000);
+        }
+
+        char hex_buf[16];
+        std::ostringstream msg;
+        msg << "Motor initialization failed: only " << total_got
+            << "/6 arm motors responded (minimum required: "
+            << cfg_.min_motors_required
+            << "). Check that motors are powered on and CAN bus is connected.";
+        for (size_t i = 0; i < 6; ++i) {
+            if (!got_initial[i]) {
+                std::snprintf(hex_buf, sizeof(hex_buf), "0x%02X", cfg_.motors[i].master_id);
+                msg << "\n  MISSING: " << cfg_.motors[i].name
+                    << " (slave=" << cfg_.motors[i].slave_id
+                    << " master=" << hex_buf << ")";
+            }
+        }
+        throw std::runtime_error(msg.str());
+    } else if (total_got < 6) {
+        std::fprintf(stderr, "WARNING: only got initial state for %d/6 arm motors (min_required=%d)!\n",
+                     total_got, cfg_.min_motors_required);
+        for (size_t i = 0; i < 6; ++i) {
+            if (!got_initial[i]) {
+                std::fprintf(stderr, "  MISSING: %s (slave=%d master=0x%02X) — pos will be 0!\n",
+                             cfg_.motors[i].name.c_str(), cfg_.motors[i].slave_id,
+                             cfg_.motors[i].master_id);
+            }
+        }
+    } else {
+        std::fprintf(stderr, "All 6 arm motors initial state read successfully\n");
+    }
+
+    parser_.clear();
+}
+
+void RtControlLoop::calibrate_gripper() {
+    if (cfg_.motors.size() < 7) return;
+    const auto& gm = cfg_.motors[6];
+
+    uint8_t frame[30];
+    uint8_t rx_buf[256];
+    const auto& lim = get_limits(gm.type);
+
+    build_switch_mode_frame(frame, gm.slave_id, 3);  // VEL
+    send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 100000);
+
+    build_enable_frame(frame, gm.slave_id);
+    send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 100000);
+
+    std::fprintf(stderr, "Gripper calibrating (opening until torque spike)...\n");
+    std::vector<std::array<uint8_t, RX_PACKET_LEN>> packets;
+    int cal_iterations = 0;
+    constexpr int MAX_CAL_ITERATIONS = 2000;  // ~10s at 5ms per iteration
+    constexpr float TORQUE_THRESHOLD = 0.7f;  // match Python threshold
+    constexpr float CAL_VELOCITY = 5.0f;      // gentle homing speed
+
+    const uint64_t cal_deadline_ns = now_ns() +
+        static_cast<uint64_t>(cfg_.gripper_cal_timeout_s * 1e9);
+
+    // Send VEL command ONCE to start the gripper moving (open direction)
+    build_vel_frame(frame, gm.slave_id, CAL_VELOCITY);
+    send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 5000);
+
+    // Poll with refresh frames to read torque (like Python version)
+    while (cal_iterations < MAX_CAL_ITERATIONS && now_ns() < cal_deadline_ns) {
+        build_refresh_frame(frame, gm.slave_id);
+        size_t n = send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 10000);
+
+        if (n > 0) {
+            parser_.feed(rx_buf, n);
+            packets.clear();
+            parser_.extract(packets);
+
+            for (const auto& pkt : packets) {
+                if (decode_cmd(pkt.data()) == 0x11) {
+                    auto st = decode_motor_state(pkt.data(), lim);
+                    ++cal_iterations;
+                    if (cal_iterations % 20 == 0) {
+                        std::fprintf(stderr, "  gripper cal [%d/%d]: pos=%.3f tau=%.3f (threshold=%.1f)\n",
+                                     cal_iterations, MAX_CAL_ITERATIONS, st.q, st.tau, TORQUE_THRESHOLD);
+                    }
+                    if (st.tau > TORQUE_THRESHOLD) {
+                        build_vel_frame(frame, gm.slave_id, 0.0f);
+                        send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 50000);
+                        build_disable_frame(frame, gm.slave_id);
+                        send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 100000);
+                        build_set_zero_frame(frame, gm.slave_id);
+                        send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 200000);
+                        sleep_ms(200);
+
+                        // Back off slightly from the hard stop so the open
+                        // position is force-free.  cfg_.gripper_open_pos is
+                        // a small offset (default 0.0) in the close direction
+                        // (negative = towards closed).
+                        gripper_open_pos_ = cfg_.gripper_open_pos;
+
+                        build_enable_frame(frame, gm.slave_id);
+                        send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 100000);
+                        goto calibration_done;
+                    }
+                }
+            }
+        }
+        sleep_ms(10);  // match Python's time.sleep(0.01)
+    }
+
+    // Timeout — stop gripper and throw
+    build_vel_frame(frame, gm.slave_id, 0.0f);
+    send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 50000);
+    build_disable_frame(frame, gm.slave_id);
+    send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 100000);
+    {
+        std::string msg = "Gripper calibration timed out after " +
+            std::to_string(cfg_.gripper_cal_timeout_s) + "s (" +
+            std::to_string(cal_iterations) + " valid packets received). ";
+        if (cal_iterations == 0) {
+            msg += "No motor state packets were received — check that the gripper motor "
+                   "(slave=" + std::to_string(gm.slave_id) + ") is powered on.";
+        } else {
+            msg += "Torque never exceeded threshold " + std::to_string(TORQUE_THRESHOLD) +
+                   ". The gripper may be unobstructed or the threshold may need adjustment.";
+        }
+        throw std::runtime_error(msg);
+    }
+
+calibration_done:
+    parser_.clear();
+
+    build_switch_mode_frame(frame, gm.slave_id, 4);  // Torque_Pos
+    send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 100000);
+
+    // Read back actual position after set_zero + enable (like Python version)
+    build_refresh_frame(frame, gm.slave_id);
+    size_t n = send_and_recv(serial_, frame, 30, rx_buf, sizeof(rx_buf), 10000);
+    if (n > 0) {
+        std::vector<std::array<uint8_t, RX_PACKET_LEN>> pkts;
+        parser_.feed(rx_buf, n);
+        parser_.extract(pkts);
+        for (const auto& pkt : pkts) {
+            if (decode_cmd(pkt.data()) == 0x11) {
+                auto st = decode_motor_state(pkt.data(), lim);
+                state_buf_.pos[6] = st.q;
+                state_buf_.vel[6] = st.dq;
+                state_buf_.torque[6] = st.tau;
+                // Use actual encoder reading + configured offset as open pos.
+                // After set_zero, st.q is near 0.  The offset backs off from
+                // the hard stop so the open position is force-free.
+                gripper_open_pos_ = static_cast<double>(st.q) + cfg_.gripper_open_pos;
+                std::fprintf(stderr, "  gripper read-back: pos=%.4f, open_pos=%.4f (offset=%.3f)\n",
+                             st.q, gripper_open_pos_, cfg_.gripper_open_pos);
+                break;
+            }
+        }
+    }
+    parser_.clear();
+    std::fprintf(stderr, "Gripper calibrated: open position = %f\n", gripper_open_pos_);
+}
+
+// --- RT thread ---
+//
+// Pipeline strategy: responses from cycle N arrive during cycle N+1.
+//   1. Read whatever responses have arrived (from previous cycle's commands)
+//   2. Parse and update state
+//   3. Compute control
+//   4. Send all 7 commands in a burst (fast — just copies to kernel buffer)
+//   5. Sleep to next period
+//
+// This avoids blocking on tcdrain or read_with_timeout in the hot path.
+// State is one cycle (4ms) behind, which is acceptable for impedance control.
+
+void RtControlLoop::rt_thread_func() {
+    rt_active_ = apply_rt_scheduling(cfg_.rt_priority, cfg_.rt_cpu_affinity, cfg_.rt_use_mlockall, cfg_.loop_hz);
+    if (rt_active_) {
+        std::fprintf(stderr, "RT scheduling active (SCHED_FIFO priority %d)\n", cfg_.rt_priority);
+    } else {
+        std::fprintf(stderr, "RT scheduling not available, using default scheduler\n");
+    }
+
+    const uint64_t period_ns = static_cast<uint64_t>(1e9 / cfg_.loop_hz);
+    const double target_us = 1e6 / cfg_.loop_hz;
+    uint64_t next_wakeup = now_ns();
+
+    std::array<double, 7> cur_pos = {};
+    std::array<double, 7> cur_vel = {};
+    std::array<double, 7> cur_torque = {};
+
+    for (int i = 0; i < 7; ++i) {
+        cur_pos[static_cast<size_t>(i)] = state_buf_.pos[static_cast<size_t>(i)];
+        cur_vel[static_cast<size_t>(i)] = state_buf_.vel[static_cast<size_t>(i)];
+        cur_torque[static_cast<size_t>(i)] = state_buf_.torque[static_cast<size_t>(i)];
+    }
+
+    uint8_t tx_frame[30];
+    uint8_t rx_buf[512];
+    std::vector<std::array<uint8_t, RX_PACKET_LEN>> packets;
+
+    std::array<double, 6> pos_lo, pos_hi;
+    for (int i = 0; i < 6; ++i) {
+        pos_lo[static_cast<size_t>(i)] = cfg_.joint_pos_limits[static_cast<size_t>(2 * i)];
+        pos_hi[static_cast<size_t>(i)] = cfg_.joint_pos_limits[static_cast<size_t>(2 * i + 1)];
+    }
+
+    const auto& dm4310_lim = get_limits(MotorType::DM4310);
+    double gripper_vel_emit = static_cast<double>(dm4310_lim.dq_max) * cfg_.emit_velocity_scale;
+    double gripper_i_des_emit = cfg_.max_gripper_torque_nm / cfg_.torque_constant * cfg_.emit_current_scale;
+
+    uint64_t loop_count = 0;
+
+    // Comm loss state machine
+    bool comm_error_disable_sent = false;
+
+    // Warmup phase: send refresh frames for a few cycles to fill the pipeline
+    // before sending MIT commands. This ensures cur_pos is populated from
+    // actual motor feedback, not zeros.
+    constexpr int WARMUP_CYCLES = 10;
+
+    while (running_.load(std::memory_order_acquire)) {
+        uint64_t t0 = now_ns();
+        ++loop_count;
+        bool debug = false;
+
+        // 1. Read responses from PREVIOUS cycle (non-blocking — grab everything available)
+        size_t total_rx = 0;
+        for (int pass = 0; pass < 3; ++pass) {
+            size_t n = serial_.read_all(rx_buf, sizeof(rx_buf));
+            if (n == 0) break;
+            total_rx += n;
+            parser_.feed(rx_buf, n);
+        }
+
+        // Communication loss tracking
+        health_rt_.total_rx_bytes += total_rx;
+        if (total_rx == 0) {
+            ++health_rt_.consecutive_empty_cycles;
+        } else {
+            health_rt_.consecutive_empty_cycles = 0;
+        }
+
+        // 2. Parse received packets and update motor state
+        packets.clear();
+        parser_.extract(packets);
+
+        if (debug) {
+            std::fprintf(stderr, "[cycle %llu] rx_bytes=%zu packets=%zu\n",
+                         (unsigned long long)loop_count, total_rx, packets.size());
+        }
+
+        uint8_t motor_responded = 0;  // bitmask, bit i = motor i responded this cycle
+
+        for (const auto& pkt : packets) {
+            uint32_t can_id = decode_can_id(pkt.data());
+            uint8_t pkt_cmd = decode_cmd(pkt.data());
+            if (pkt_cmd != 0x11) {
+                if (debug) std::fprintf(stderr, "  skip pkt can_id=0x%03X cmd=0x%02X\n", can_id, pkt_cmd);
+                continue;
+            }
+            if (is_param_response(pkt.data())) continue;
+
+            bool matched = false;
+            for (size_t i = 0; i < cfg_.motors.size(); ++i) {
+                const auto& m = cfg_.motors[i];
+                bool match = (can_id == m.slave_id) ||
+                             (can_id == m.master_id) ||
+                             (can_id == 0 && decode_response_id(pkt.data()) == (m.master_id & 0x0F));
+                if (match) {
+                    auto st = decode_motor_state(pkt.data(), get_limits(m.type));
+                    cur_pos[i] = st.q;
+                    cur_vel[i] = st.dq;
+                    cur_torque[i] = st.tau;
+                    if (i < 7) motor_responded |= (1u << i);
+                    matched = true;
+                    if (debug) {
+                        std::fprintf(stderr, "  motor[%zu] %s: pos=%.4f vel=%.4f tau=%.4f (can_id=0x%03X)\n",
+                                     i, m.name.c_str(), st.q, st.dq, st.tau, can_id);
+                    }
+                    break;
+                }
+            }
+            if (!matched && debug) {
+                std::fprintf(stderr, "  UNMATCHED pkt can_id=0x%03X\n", can_id);
+            }
+        }
+
+        // Per-motor staleness tracking
+        for (size_t i = 0; i < cfg_.motors.size() && i < 7; ++i) {
+            if (motor_responded & (1u << i)) {
+                health_rt_.motor_last_seen_cycle[i] = loop_count;
+                health_rt_.motor_stale[i] = false;
+            } else {
+                if (loop_count - health_rt_.motor_last_seen_cycle[i] >=
+                    static_cast<uint64_t>(cfg_.per_motor_stale_threshold)) {
+                    health_rt_.motor_stale[i] = true;
+                }
+            }
+        }
+
+        // Comm error state machine (only active after warmup)
+        if (loop_count > WARMUP_CYCLES) {
+            if (!health_rt_.comm_loss) {
+                if (health_rt_.consecutive_empty_cycles >= cfg_.max_consecutive_empty_cycles) {
+                    health_rt_.comm_loss = true;
+                    comm_error_disable_sent = false;
+                    std::fprintf(stderr, "[cycle %llu] COMM ERROR: %d consecutive empty cycles, "
+                                 "entering comm loss state (action=%s)\n",
+                                 (unsigned long long)loop_count,
+                                 health_rt_.consecutive_empty_cycles,
+                                 cfg_.comm_loss_action == CommLossAction::DISABLE ? "DISABLE" : "HOLD");
+                }
+            }
+        }
+
+        // 3. Write state (seqlock) — so Python sees the latest even during computation
+        {
+            uint64_t s = state_seq_.load(std::memory_order_relaxed);
+            state_seq_.store(s + 1, std::memory_order_release);
+            state_buf_.pos = cur_pos;
+            state_buf_.vel = cur_vel;
+            state_buf_.torque = cur_torque;
+            state_seq_.store(s + 2, std::memory_order_release);
+        }
+
+        // Publish health state (seqlock)
+        health_rt_.loop_count = loop_count;
+        {
+            uint64_t s = health_seq_.load(std::memory_order_relaxed);
+            health_seq_.store(s + 1, std::memory_order_release);
+            health_buf_ = health_rt_;
+            health_seq_.store(s + 2, std::memory_order_release);
+        }
+
+        // During warmup, send refresh frames only (no MIT commands).
+        // This populates cur_pos from actual motor feedback before we start controlling.
+        if (loop_count <= WARMUP_CYCLES) {
+            for (size_t i = 0; i < cfg_.motors.size(); ++i) {
+                const auto& m = cfg_.motors[i];
+                build_refresh_frame(tx_frame, m.slave_id);
+                if (!serial_.write(tx_frame, 30)) {
+                    ++health_rt_.total_write_errors;
+                }
+                ++health_rt_.total_tx_frames;
+            }
+            if (debug) {
+                std::fprintf(stderr, "  [warmup %llu/%d] sent refresh frames, cur_pos=[",
+                             (unsigned long long)loop_count, WARMUP_CYCLES);
+                for (int i = 0; i < 6; ++i) std::fprintf(stderr, "%.4f%s", cur_pos[static_cast<size_t>(i)], i<5?", ":"");
+                std::fprintf(stderr, "]\n");
+            }
+
+            // At end of warmup, update command buffer and slew target to match actual positions
+            if (loop_count == WARMUP_CYCLES) {
+                uint64_t s = cmd_seq_.load(std::memory_order_relaxed);
+                cmd_seq_.store(s + 1, std::memory_order_release);
+                for (int i = 0; i < 6; ++i) {
+                    cmd_buf_.q_des[static_cast<size_t>(i)] = cur_pos[static_cast<size_t>(i)];
+                }
+                cmd_buf_.timestamp_ns = now_ns();
+                cmd_seq_.store(s + 2, std::memory_order_release);
+
+                // Initialize slew target to actual motor positions
+                for (int i = 0; i < 6; ++i) {
+                    slew_target_[static_cast<size_t>(i)] = cur_pos[static_cast<size_t>(i)];
+                }
+
+                // Reset comm counters so warmup's empty cycles don't trigger comm loss
+                health_rt_.consecutive_empty_cycles = 0;
+
+                std::fprintf(stderr, "  [warmup done] command buffer and slew target initialized to actual pos\n");
+            }
+
+            uint64_t t1 = now_ns();
+            double cycle_us = static_cast<double>(t1 - t0) / 1000.0;
+            perf_.record(cycle_us, target_us);
+            next_wakeup += period_ns;
+            if (next_wakeup < t1) next_wakeup = t1 + period_ns;
+            sleep_until_ns(next_wakeup);
+            continue;
+        }
+
+        // 4. Handle error reset request (from Python thread)
+        if (error_reset_requested_.exchange(false, std::memory_order_acq_rel)) {
+            safety_state_.damping_mode = false;
+            safety_state_.overcurrent_count = 0;
+            safety_state_.overspeed_count = 0;
+            health_rt_.comm_loss = false;
+            health_rt_.consecutive_empty_cycles = 0;
+            comm_error_disable_sent = false;
+            // Snap slew target to current position to prevent jump after reset
+            for (int i = 0; i < 6; ++i) {
+                slew_target_[static_cast<size_t>(i)] = cur_pos[static_cast<size_t>(i)];
+            }
+            error_reset_ack_.fetch_add(1, std::memory_order_release);
+            std::fprintf(stderr, "[cycle %llu] Error reset acknowledged\n",
+                         (unsigned long long)loop_count);
+        }
+
+        // 5. Read commands (seqlock)
+        CommandBuffer cmd;
+        for (int attempt = 0; attempt < 100; ++attempt) {
+            uint64_t s1 = cmd_seq_.load(std::memory_order_acquire);
+            if (s1 & 1) continue;
+            cmd = cmd_buf_;
+            uint64_t s2 = cmd_seq_.load(std::memory_order_acquire);
+            if (s1 == s2) break;
+        }
+
+        // 6. Watchdog
+        uint64_t cmd_age_ns = t0 - cmd.timestamp_ns;
+        double cmd_age_s = static_cast<double>(cmd_age_ns) / 1e9;
+        if (cmd_age_s > cfg_.command_timeout_s) {
+            for (int i = 0; i < 6; ++i) {
+                cmd.q_des[static_cast<size_t>(i)] = cur_pos[static_cast<size_t>(i)];
+            }
+        }
+
+        // 7. Slew rate limiting
+        for (int i = 0; i < 6; ++i) {
+            double max_delta = cfg_.max_pos_delta_per_cycle[static_cast<size_t>(i)];
+            if (max_delta > 0.0) {
+                double diff = cmd.q_des[static_cast<size_t>(i)] - slew_target_[static_cast<size_t>(i)];
+                if (diff > max_delta) diff = max_delta;
+                else if (diff < -max_delta) diff = -max_delta;
+                slew_target_[static_cast<size_t>(i)] += diff;
+            } else {
+                // Rate limiting disabled for this joint — pass through
+                slew_target_[static_cast<size_t>(i)] = cmd.q_des[static_cast<size_t>(i)];
+            }
+        }
+
+        // 8. Gravity compensation
+        std::array<double, 6> tau_ff = {};
+        if (grav_comp_.is_loaded()) {
+            grav_comp_.compute(cur_pos.data(), tau_ff.data());
+            for (int i = 0; i < 6; ++i) {
+                tau_ff[static_cast<size_t>(i)] *= cfg_.gravity_comp_scale;
+            }
+        }
+
+        // 9. Safety (uses slew-limited target, not raw q_des)
+        std::array<double, 6> kp = cfg_.default_kp;
+        std::array<double, 6> q_des;
+        std::copy(slew_target_.begin(), slew_target_.end(), q_des.begin());
+        apply_safety(cur_pos.data(), cur_vel.data(), cur_torque.data(),
+                     q_des.data(), kp.data(), tau_ff.data(),
+                     pos_lo.data(), pos_hi.data(),
+                     cfg_.joint_torque_limits.data(), cfg_.joint_velocity_limits.data(),
+                     cfg_.limit_buffer,
+                     cfg_.overcurrent_threshold, cfg_.overspeed_threshold,
+                     6, safety_state_);
+
+        // Update health with safety state
+        health_rt_.damping_mode = safety_state_.damping_mode;
+        health_rt_.overcurrent_count = safety_state_.overcurrent_count;
+        health_rt_.overspeed_count = safety_state_.overspeed_count;
+
+        if (debug) {
+            std::fprintf(stderr, "  [cycle %llu] q_des=[", (unsigned long long)loop_count);
+            for (int i = 0; i < 6; ++i) std::fprintf(stderr, "%.4f%s", q_des[static_cast<size_t>(i)], i<5?", ":"");
+            std::fprintf(stderr, "] cur_pos=[");
+            for (int i = 0; i < 6; ++i) std::fprintf(stderr, "%.4f%s", cur_pos[static_cast<size_t>(i)], i<5?", ":"");
+            std::fprintf(stderr, "] tau_ff=[");
+            for (int i = 0; i < 6; ++i) std::fprintf(stderr, "%.3f%s", tau_ff[static_cast<size_t>(i)], i<5?", ":"");
+            std::fprintf(stderr, "] cmd_age=%.3fs\n", cmd_age_s);
+        }
+
+        // 10. Send commands — gated by comm error state
+        if (health_rt_.comm_loss) {
+            if (cfg_.comm_loss_action == CommLossAction::DISABLE && !comm_error_disable_sent) {
+                // Send disable frames ONCE when first entering error state
+                for (size_t i = 0; i < cfg_.motors.size(); ++i) {
+                    build_disable_frame(tx_frame, cfg_.motors[i].slave_id);
+                    if (!serial_.write(tx_frame, 30)) {
+                        ++health_rt_.total_write_errors;
+                    }
+                    ++health_rt_.total_tx_frames;
+                }
+                comm_error_disable_sent = true;
+            } else if (cfg_.comm_loss_action == CommLossAction::HOLD) {
+                // Send MIT with kp=0 (damping only) to gently decelerate
+                for (size_t i = 0; i < 6 && i < cfg_.motors.size(); ++i) {
+                    const auto& m = cfg_.motors[i];
+                    const auto& lim = get_limits(m.type);
+                    build_mit_frame(tx_frame, m.slave_id,
+                                   0.0f,  // kp = 0
+                                   static_cast<float>(cfg_.default_kd[i]),
+                                   static_cast<float>(cur_pos[i]),
+                                   0.0f, 0.0f, lim);
+                    if (!serial_.write(tx_frame, 30)) {
+                        ++health_rt_.total_write_errors;
+                    }
+                    ++health_rt_.total_tx_frames;
+                }
+            }
+            // In DISABLE mode after first cycle: send nothing (motors already disabled)
+        } else {
+            // Normal operation — send MIT frames for arm joints
+            for (size_t i = 0; i < 6 && i < cfg_.motors.size(); ++i) {
+                const auto& m = cfg_.motors[i];
+                const auto& lim = get_limits(m.type);
+                build_mit_frame(tx_frame, m.slave_id,
+                               static_cast<float>(kp[i]),
+                               static_cast<float>(cfg_.default_kd[i]),
+                               static_cast<float>(q_des[i]),
+                               0.0f,
+                               static_cast<float>(tau_ff[i]),
+                               lim);
+                if (!serial_.write(tx_frame, 30)) {
+                    ++health_rt_.total_write_errors;
+                }
+                ++health_rt_.total_tx_frames;
+            }
+
+            if (cfg_.motors.size() >= 7) {
+                const auto& gm = cfg_.motors[6];
+                double gripper_q = gripper_open_pos_ +
+                    cmd.gripper_des * (cfg_.gripper_closed_pos - gripper_open_pos_);
+                build_emit_frame(tx_frame, gm.slave_id,
+                                static_cast<float>(gripper_q),
+                                static_cast<float>(gripper_vel_emit),
+                                static_cast<float>(gripper_i_des_emit));
+                if (!serial_.write(tx_frame, 30)) {
+                    ++health_rt_.total_write_errors;
+                }
+                ++health_rt_.total_tx_frames;
+            }
+        }
+
+        // 11. Record perf
+        uint64_t t1 = now_ns();
+        double cycle_us = static_cast<double>(t1 - t0) / 1000.0;
+        perf_.record(cycle_us, target_us);
+
+        // 12. Sleep to next period
+        next_wakeup += period_ns;
+        if (next_wakeup < t1) {
+            next_wakeup = t1 + period_ns;
+        }
+        sleep_until_ns(next_wakeup);
+    }
+}
+
+} // namespace trlc

--- a/csrc/control_loop.h
+++ b/csrc/control_loop.h
@@ -1,0 +1,207 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "dm_protocol.h"
+#include "gravity_comp.h"
+#include "motor_defs.h"
+#include "perf_counters.h"
+#include "safety.h"
+#include "serial_port.h"
+
+namespace trlc {
+
+enum class CommLossAction : int {
+    HOLD = 0,     // Send MIT with kp=0 (damping only) — motors gently brake
+    DISABLE = 1,  // Send disable frames to all motors — motors go limp
+};
+
+struct RtLoopConfig {
+    std::string serial_port = "/dev/ttyACM0";
+    double loop_hz = 250.0;
+
+    std::vector<MotorDescriptor> motors;  // 7 entries (6 arm + gripper)
+
+    std::array<double, 6> default_kp = {80, 70, 60, 20, 20, 10};
+    std::array<double, 6> default_kd = {5, 5, 4, 1, 1, 1};
+
+    // Flat [lo0,hi0,lo1,hi1,...] for 6 joints
+    std::array<double, 12> joint_pos_limits = {
+        -3.14159265, 3.14159265,   // joint_1
+        -3.14159265, 3.14159265,   // joint_2
+        -3.14159265, 3.14159265,   // joint_3
+        -1.74532925, 1.74532925,   // joint_4 (100 deg)
+        -1.57079633, 1.57079633,   // joint_5 (90 deg)
+        -3.14159265, 3.14159265,   // joint_6
+    };
+    std::array<double, 6> joint_torque_limits = {28, 28, 28, 10, 10, 10};
+    std::array<double, 6> joint_velocity_limits = {5.0, 5.0, 5.0, 15.0, 15.0, 15.0};
+    double limit_buffer = 0.05;
+
+    std::string model_path;  // URDF/XML for gravity comp, empty = disabled
+    double gravity_comp_scale = 1.0;
+
+    double command_timeout_s = 0.5;
+    int overcurrent_threshold = 20;
+    int overspeed_threshold = 5;
+
+    // Motor initialization
+    int min_motors_required = 6;          // throw if fewer arm motors respond
+
+    // Gripper
+    // gripper_open_pos: offset from the calibrated zero (hard stop) in the
+    // close direction.  A small negative value backs off from the hard stop
+    // so the gripper rests force-free when commanded fully open.
+    double gripper_open_pos = 0.0;
+    double gripper_closed_pos = -4.7;
+    double max_gripper_torque_nm = 1.0;
+    double torque_constant = 0.945;
+    double emit_velocity_scale = 100.0;
+    double emit_current_scale = 1000.0;
+    double gripper_cal_timeout_s = 10.0;  // wall-clock timeout for calibration
+
+    // Slew rate limiting (max position change per cycle in radians)
+    // At 250 Hz, 0.01 rad/cycle = 2.5 rad/s max slew rate.
+    // Set to 0.0 to disable rate limiting for a joint.
+    std::array<double, 6> max_pos_delta_per_cycle = {0.02, 0.02, 0.02, 0.06, 0.06, 0.06};
+
+    // Communication loss detection
+    int max_consecutive_empty_cycles = 50;  // 50 cycles = 200ms at 250Hz
+    CommLossAction comm_loss_action = CommLossAction::DISABLE;
+    int per_motor_stale_threshold = 100;    // flag motor after 100 cycles (~400ms)
+
+    // Shutdown
+    bool disable_torque_on_disconnect = true;
+
+    // RT
+    int rt_priority = 80;
+    int rt_cpu_affinity = -1;
+    bool rt_use_mlockall = true;
+};
+
+struct JointState {
+    std::array<double, 6> pos = {};
+    std::array<double, 6> vel = {};
+    std::array<double, 6> torque = {};
+};
+
+struct GripperState {
+    double pos = 0.0;
+    double torque = 0.0;
+};
+
+struct HealthState {
+    // Safety
+    bool damping_mode = false;
+    int overcurrent_count = 0;
+    int overspeed_count = 0;
+
+    // Communication
+    bool comm_loss = false;
+    int consecutive_empty_cycles = 0;
+    uint64_t total_rx_bytes = 0;
+    uint64_t total_tx_frames = 0;
+    uint64_t total_write_errors = 0;
+    std::array<uint64_t, 7> motor_last_seen_cycle = {};
+    std::array<bool, 7> motor_stale = {};
+
+    // Loop metadata
+    uint64_t loop_count = 0;
+};
+
+class RtControlLoop {
+public:
+    explicit RtControlLoop(const RtLoopConfig& cfg);
+    ~RtControlLoop();
+
+    RtControlLoop(const RtControlLoop&) = delete;
+    RtControlLoop& operator=(const RtControlLoop&) = delete;
+
+    void start();
+    void stop();
+
+    // Commands (lock-free writes via seqlock)
+    void command_joint_pos(const double* q6);
+    void command_gripper(double normalized);  // 0=open, 1=closed
+
+    // State (lock-free reads via seqlock)
+    JointState get_joint_state() const;
+    GripperState get_gripper_state() const;
+
+    // Health and error state (lock-free read via seqlock)
+    HealthState get_health() const;
+
+    // Reset safety errors (damping mode, overcurrent, overspeed, comm loss).
+    // Blocks until the RT thread processes the reset, with a timeout.
+    // Throws std::runtime_error if not acknowledged within timeout_ms.
+    // Pass timeout_ms=0 for fire-and-forget (non-blocking).
+    void reset_errors(int timeout_ms = 100);
+
+    // Diagnostics
+    PerfSnapshot get_perf() const;
+    size_t read_cycle_times(float* buf, size_t max) const;
+    void reset_perf(int timeout_ms = 100);
+    bool is_running() const { return running_.load(std::memory_order_acquire); }
+    bool is_rt_active() const { return rt_active_; }
+
+private:
+    void configure_motors();
+    void calibrate_gripper();
+    void rt_thread_func();
+
+    // Seqlock helpers
+    struct CommandBuffer {
+        std::array<double, 6> q_des = {};
+        double gripper_des = 0.0;
+        uint64_t timestamp_ns = 0;
+    };
+
+    struct StateBuffer {
+        std::array<double, 7> pos = {};
+        std::array<double, 7> vel = {};
+        std::array<double, 7> torque = {};
+    };
+
+    RtLoopConfig cfg_;
+    SerialPort serial_;
+    GravityCompensator grav_comp_;
+    PacketParser parser_;
+    PerfCounters perf_;
+    SafetyState safety_state_;
+
+    // Command seqlock (Python writes, RT reads)
+    alignas(64) CommandBuffer cmd_buf_;
+    alignas(64) std::atomic<uint64_t> cmd_seq_{0};
+
+    // State seqlock (RT writes, Python reads)
+    alignas(64) StateBuffer state_buf_;
+    alignas(64) std::atomic<uint64_t> state_seq_{0};
+
+    // Health seqlock (RT writes, Python reads)
+    alignas(64) HealthState health_buf_;
+    alignas(64) std::atomic<uint64_t> health_seq_{0};
+
+    // RT-thread-only mutable health tracking
+    HealthState health_rt_;
+
+    // Error reset coordination (Python sets, RT thread increments ack after processing)
+    std::atomic<bool> error_reset_requested_{false};
+    std::atomic<uint64_t> error_reset_ack_{0};
+
+    std::atomic<bool> running_{false};
+    std::thread thread_;
+    bool rt_active_ = false;
+
+    // Gripper calibration result
+    double gripper_open_pos_ = 0.0;
+
+    // Slew rate limiter state (RT thread only)
+    std::array<double, 6> slew_target_ = {};
+};
+
+} // namespace trlc

--- a/csrc/control_loop.h
+++ b/csrc/control_loop.h
@@ -95,6 +95,16 @@ struct GripperState {
     double torque = 0.0;
 };
 
+// Timestamped state snapshot used by get_state_at() for timestamp-aligned
+// observation assembly. ts_mono_ns is the CLOCK_MONOTONIC time at which the
+// RT thread observed and published this state (same time base the camera
+// daemon uses for its frame timestamps).
+struct TimedJointSnapshot {
+    uint64_t ts_mono_ns = 0;
+    JointState joints;
+    GripperState gripper;
+};
+
 struct HealthState {
     // Safety
     bool damping_mode = false;
@@ -132,6 +142,17 @@ public:
     // State (lock-free reads via seqlock)
     JointState get_joint_state() const;
     GripperState get_gripper_state() const;
+
+    // Timestamp-aligned state lookup. Returns the latest snapshot whose
+    // ts_mono_ns <= the requested time, sourced from a small ring of recent
+    // RT-thread publications. Returns true on success; false if no sample
+    // at-or-before `ts_ns` is available (target time predates the oldest
+    // still-buffered slot, or no samples have been published yet).
+    //
+    // Used by timestamp-aligned observation assembly (Option C): the record /
+    // rollout loop picks the latest camera frame's kernel capture timestamp
+    // as the reference T and asks every other sensor for its state at T.
+    bool get_state_at(uint64_t ts_ns, TimedJointSnapshot& out) const;
 
     // Health and error state (lock-free read via seqlock)
     HealthState get_health() const;
@@ -181,6 +202,19 @@ private:
     // State seqlock (RT writes, Python reads)
     alignas(64) StateBuffer state_buf_;
     alignas(64) std::atomic<uint64_t> state_seq_{0};
+
+    // Timestamped state ring (RT writes, Python reads via get_state_at).
+    // 256 slots at 250 Hz ≈ 1 s of history — plenty of margin for aligning
+    // observations to camera frames that are 5–30 ms older than the tick.
+    static constexpr size_t STATE_RING_SIZE = 256;
+    struct RingSlot {
+        uint64_t ts_mono_ns;
+        std::array<double, 7> pos;     // 6 joints + gripper
+        std::array<double, 7> vel;
+        std::array<double, 7> torque;
+    };
+    alignas(64) std::array<RingSlot, STATE_RING_SIZE> state_ring_;
+    alignas(64) std::atomic<uint64_t> state_ring_write_idx_{0};
 
     // Health seqlock (RT writes, Python reads)
     alignas(64) HealthState health_buf_;

--- a/csrc/control_loop.h
+++ b/csrc/control_loop.h
@@ -149,7 +149,7 @@ public:
     // at-or-before `ts_ns` is available (target time predates the oldest
     // still-buffered slot, or no samples have been published yet).
     //
-    // Used by timestamp-aligned observation assembly (Option C): the record /
+    // Used by timestamp-aligned observation assembly: the record /
     // rollout loop picks the latest camera frame's kernel capture timestamp
     // as the reference T and asks every other sensor for its state at T.
     bool get_state_at(uint64_t ts_ns, TimedJointSnapshot& out) const;

--- a/csrc/dm_protocol.h
+++ b/csrc/dm_protocol.h
@@ -1,0 +1,259 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "motor_defs.h"
+
+namespace trlc {
+
+// --- Quantization (matches DM_CAN.py float_to_uint / uint_to_float) ---
+
+inline uint16_t float_to_uint(float x, float x_min, float x_max, int bits) {
+    if (x < x_min) x = x_min;
+    if (x > x_max) x = x_max;
+    float span = x_max - x_min;
+    float norm = (x - x_min) / span;
+    return static_cast<uint16_t>(norm * ((1 << bits) - 1));
+}
+
+inline float uint_to_float(uint16_t x, float x_min, float x_max, int bits) {
+    float span = x_max - x_min;
+    float norm = static_cast<float>(x) / ((1 << bits) - 1);
+    return norm * span + x_min;
+}
+
+// --- Send frame format ---
+// 30-byte frame: header + CAN data, matches DM_CAN.py send_data_frame layout
+// [0x55, 0xAA, 0x1E, 0x03, 0x01, 0x00, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00, 0x00,
+//  id_lo, id_hi, 0, 0, 0x00, 0x08, 0x00, 0x00, data[0..7], 0x00]
+
+static constexpr uint8_t FRAME_TEMPLATE[30] = {
+    0x55, 0xAA, 0x1E, 0x03, 0x01, 0x00, 0x00, 0x00,
+    0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+// Fills a 30-byte buffer with a send frame for the given motor_id and 8-byte data payload.
+inline void build_send_frame(uint8_t* buf30, uint16_t motor_id, const uint8_t* data8) {
+    std::memcpy(buf30, FRAME_TEMPLATE, 30);
+    buf30[13] = motor_id & 0xFF;
+    buf30[14] = (motor_id >> 8) & 0xFF;
+    std::memcpy(buf30 + 21, data8, 8);
+}
+
+// --- MIT mode frame ---
+
+inline void build_mit_frame(uint8_t* buf30, uint16_t slave_id,
+                            float kp, float kd, float q, float dq, float tau,
+                            const MotorLimits& lim) {
+    uint16_t kp_uint  = float_to_uint(kp, 0.0f, 500.0f, 12);
+    uint16_t kd_uint  = float_to_uint(kd, 0.0f, 5.0f, 12);
+    uint16_t q_uint   = float_to_uint(q, -lim.q_max, lim.q_max, 16);
+    uint16_t dq_uint  = float_to_uint(dq, -lim.dq_max, lim.dq_max, 12);
+    uint16_t tau_uint = float_to_uint(tau, -lim.tau_max, lim.tau_max, 12);
+
+    uint8_t data[8];
+    data[0] = (q_uint >> 8) & 0xFF;
+    data[1] = q_uint & 0xFF;
+    data[2] = dq_uint >> 4;
+    data[3] = ((dq_uint & 0xF) << 4) | ((kp_uint >> 8) & 0xF);
+    data[4] = kp_uint & 0xFF;
+    data[5] = kd_uint >> 4;
+    data[6] = ((kd_uint & 0xF) << 4) | ((tau_uint >> 8) & 0xF);
+    data[7] = tau_uint & 0xFF;
+
+    build_send_frame(buf30, slave_id, data);
+}
+
+// --- EMIT (Torque_Pos) mode frame ---
+
+inline void build_emit_frame(uint8_t* buf30, uint16_t slave_id,
+                             float pos, float vel, float i_des) {
+    // motor_id for EMIT = 0x300 + slave_id
+    uint16_t motor_id = 0x300 + slave_id;
+
+    // Position is packed as IEEE 754 float32 (little-endian)
+    uint8_t data[8] = {};
+    float pos_val = pos;
+    std::memcpy(data, &pos_val, 4);
+
+    uint16_t vel_uint = static_cast<uint16_t>(vel);
+    uint16_t ides_uint = static_cast<uint16_t>(i_des);
+    data[4] = vel_uint & 0xFF;
+    data[5] = vel_uint >> 8;
+    data[6] = ides_uint & 0xFF;
+    data[7] = ides_uint >> 8;
+
+    build_send_frame(buf30, motor_id, data);
+}
+
+// --- VEL mode frame ---
+
+inline void build_vel_frame(uint8_t* buf30, uint16_t slave_id, float vel) {
+    uint16_t motor_id = 0x200 + slave_id;
+    uint8_t data[8] = {};
+    float vel_val = vel;
+    std::memcpy(data, &vel_val, 4);
+    build_send_frame(buf30, motor_id, data);
+}
+
+// --- Control command frames (enable/disable/set-zero) ---
+
+inline void build_enable_frame(uint8_t* buf30, uint16_t slave_id) {
+    uint8_t data[8] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFC};
+    build_send_frame(buf30, slave_id, data);
+}
+
+inline void build_disable_frame(uint8_t* buf30, uint16_t slave_id) {
+    uint8_t data[8] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFD};
+    build_send_frame(buf30, slave_id, data);
+}
+
+inline void build_set_zero_frame(uint8_t* buf30, uint16_t slave_id) {
+    uint8_t data[8] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE};
+    build_send_frame(buf30, slave_id, data);
+}
+
+// --- Refresh motor status (0x7FF + 0xCC) ---
+
+inline void build_refresh_frame(uint8_t* buf30, uint16_t slave_id) {
+    uint8_t data[8] = {};
+    data[0] = slave_id & 0xFF;
+    data[1] = (slave_id >> 8) & 0xFF;
+    data[2] = 0xCC;
+    build_send_frame(buf30, 0x7FF, data);
+}
+
+// --- Switch control mode (parameter write RID=10) ---
+
+inline void build_switch_mode_frame(uint8_t* buf30, uint16_t slave_id, uint8_t mode) {
+    uint8_t data[8] = {};
+    data[0] = slave_id & 0xFF;
+    data[1] = (slave_id >> 8) & 0xFF;
+    data[2] = 0x55;  // write command
+    data[3] = 10;    // RID = CTRL_MODE
+    // mode as uint32 little-endian in bytes 4..7
+    data[4] = mode;
+    data[5] = 0;
+    data[6] = 0;
+    data[7] = 0;
+    build_send_frame(buf30, 0x7FF, data);
+}
+
+// --- Read parameter (RID) ---
+
+inline void build_read_param_frame(uint8_t* buf30, uint16_t slave_id, uint8_t rid) {
+    uint8_t data[8] = {};
+    data[0] = slave_id & 0xFF;
+    data[1] = (slave_id >> 8) & 0xFF;
+    data[2] = 0x33;  // read command
+    data[3] = rid;
+    build_send_frame(buf30, 0x7FF, data);
+}
+
+// --- Receive packet parsing ---
+
+static constexpr size_t RX_PACKET_LEN = 16;
+static constexpr uint8_t RX_HEADER = 0xAA;
+static constexpr uint8_t RX_TAIL   = 0x55;
+
+struct MotorState {
+    float q;
+    float dq;
+    float tau;
+};
+
+inline MotorState decode_motor_state(const uint8_t* packet, const MotorLimits& lim) {
+    // Data bytes start at offset 7 in the 16-byte packet
+    const uint8_t* data = packet + 7;
+    uint16_t q_uint   = (static_cast<uint16_t>(data[1]) << 8) | data[2];
+    uint16_t dq_uint  = (static_cast<uint16_t>(data[3]) << 4) | (data[4] >> 4);
+    uint16_t tau_uint = ((data[4] & 0x0F) << 8) | data[5];
+
+    MotorState s;
+    s.q   = uint_to_float(q_uint, -lim.q_max, lim.q_max, 16);
+    s.dq  = uint_to_float(dq_uint, -lim.dq_max, lim.dq_max, 12);
+    s.tau = uint_to_float(tau_uint, -lim.tau_max, lim.tau_max, 12);
+    return s;
+}
+
+// Extract the CAN ID from a 16-byte receive packet
+inline uint32_t decode_can_id(const uint8_t* packet) {
+    return static_cast<uint32_t>(packet[3]) |
+           (static_cast<uint32_t>(packet[4]) << 8) |
+           (static_cast<uint32_t>(packet[5]) << 16) |
+           (static_cast<uint32_t>(packet[6]) << 24);
+}
+
+// Extract the slave/master ID from the data field of a response
+inline uint8_t decode_response_id(const uint8_t* packet) {
+    // data[0] (at offset 7) contains the motor ID info
+    return packet[7] & 0x0F;
+}
+
+// CMD byte is at offset 1
+inline uint8_t decode_cmd(const uint8_t* packet) {
+    return packet[1];
+}
+
+// Check if a CMD=0x11 packet is a parameter response (not motor state).
+// Parameter responses have data[2] == 0x33 (write ack) or 0x55 (read ack).
+inline bool is_param_response(const uint8_t* packet) {
+    uint8_t d2 = packet[7 + 2];  // data[2]
+    return d2 == 0x33 || d2 == 0x55;
+}
+
+class PacketParser {
+public:
+    // Feed raw bytes, extract complete 16-byte packets
+    void feed(const uint8_t* data, size_t len) {
+        residual_.insert(residual_.end(), data, data + len);
+        // Cap residual buffer to prevent unbounded growth from corrupted data
+        if (residual_.size() > MAX_RESIDUAL) {
+            size_t excess = residual_.size() - MAX_RESIDUAL;
+            residual_.erase(residual_.begin(),
+                           residual_.begin() + static_cast<ptrdiff_t>(excess));
+        }
+    }
+
+    // Extract all complete packets from the residual buffer
+    // Returns number of packets extracted
+    size_t extract(std::vector<std::array<uint8_t, RX_PACKET_LEN>>& out) {
+        size_t count = 0;
+        size_t i = 0;
+
+        while (i + RX_PACKET_LEN <= residual_.size()) {
+            if (residual_[i] == RX_HEADER &&
+                residual_[i + RX_PACKET_LEN - 1] == RX_TAIL) {
+                std::array<uint8_t, RX_PACKET_LEN> pkt;
+                std::memcpy(pkt.data(), residual_.data() + i, RX_PACKET_LEN);
+                out.push_back(pkt);
+                i += RX_PACKET_LEN;
+                ++count;
+            } else {
+                ++i;
+            }
+        }
+
+        // Erase all scanned bytes (both junk and extracted packets).
+        // Only trailing bytes (< RX_PACKET_LEN) that may be a partial packet remain.
+        if (i > 0) {
+            residual_.erase(residual_.begin(),
+                           residual_.begin() + static_cast<ptrdiff_t>(i));
+        }
+        return count;
+    }
+
+    void clear() { residual_.clear(); }
+
+private:
+    static constexpr size_t MAX_RESIDUAL = 4096;
+    std::vector<uint8_t> residual_;
+};
+
+} // namespace trlc

--- a/csrc/gravity_comp.cpp
+++ b/csrc/gravity_comp.cpp
@@ -1,0 +1,115 @@
+#include "gravity_comp.h"
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace trlc {
+
+// Read file contents into a string.
+static std::string read_file(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return {};
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+// Strip all <visual>...</visual> and <collision>...</collision> elements
+// from a URDF.  Gravity compensation only needs the kinematic chain
+// (link masses, inertias, joint axes) — no meshes of any kind.
+static std::string strip_geometry_elements(const std::string& xml) {
+    std::string result = xml;
+    for (const char* tag : {"<visual>", "<collision>"}) {
+        std::string open_tag(tag);
+        std::string close_tag = "</" + open_tag.substr(1);  // </visual> or </collision>
+        while (true) {
+            auto start = result.find(open_tag);
+            if (start == std::string::npos) break;
+            auto end = result.find(close_tag, start);
+            if (end == std::string::npos) break;
+            result.erase(start, end + close_tag.size() - start);
+        }
+    }
+    return result;
+}
+
+GravityCompensator::~GravityCompensator() {
+    if (data_) mj_deleteData(data_);
+    if (model_) mj_deleteModel(model_);
+}
+
+bool GravityCompensator::load(const std::string& path, int ndof) {
+    ndof_ = ndof;
+    char error[1000] = {};
+
+    // Read the URDF/XML and strip <visual> and <collision> elements so
+    // MuJoCo never tries to load any mesh files (STL, OBJ, GLB).
+    std::string xml = read_file(path);
+    if (xml.empty()) {
+        std::fprintf(stderr, "gravity_comp: cannot read file: %s\n", path.c_str());
+        return false;
+    }
+    xml = strip_geometry_elements(xml);
+
+    // Load from the modified XML string.  We use a VFS with the model
+    // registered as a file so mj_loadXML can resolve relative paths for
+    // any non-mesh assets.  The meshdir is set to the URDF's directory.
+    mjVFS vfs;
+    mj_defaultVFS(&vfs);
+
+    const char* vfs_name = "model.urdf";
+    if (mj_addBufferVFS(&vfs, vfs_name, xml.data(),
+                         static_cast<int>(xml.size())) != 0) {
+        std::fprintf(stderr, "gravity_comp: mj_addBufferVFS failed\n");
+        mj_deleteVFS(&vfs);
+        return false;
+    }
+
+    model_ = mj_loadXML(vfs_name, &vfs, error, sizeof(error));
+    mj_deleteVFS(&vfs);
+
+    if (!model_) {
+        std::fprintf(stderr, "gravity_comp: mj_loadXML failed: %s\n", error);
+        return false;
+    }
+
+    if (model_->nq < ndof) {
+        std::fprintf(stderr, "gravity_comp: model has %ld DoFs but ndof=%d\n", (long)model_->nq, ndof);
+        mj_deleteModel(model_);
+        model_ = nullptr;
+        return false;
+    }
+
+    data_ = mj_makeData(model_);
+    std::fprintf(stderr, "gravity_comp: loaded %s (%ld DoF model, using first %d)\n",
+                 path.c_str(), (long)model_->nq, ndof);
+    return true;
+}
+
+void GravityCompensator::compute(const double* q, double* tau_out) {
+    if (!model_ || !data_) {
+        std::memset(tau_out, 0, static_cast<size_t>(ndof_) * sizeof(double));
+        return;
+    }
+
+    for (int i = 0; i < ndof_; ++i) {
+        data_->qpos[i] = q[i];
+    }
+    std::memset(data_->qvel, 0, static_cast<size_t>(model_->nv) * sizeof(double));
+    std::memset(data_->qacc, 0, static_cast<size_t>(model_->nv) * sizeof(double));
+
+    // Use mj_forward + qfrc_bias instead of mj_inverse + qfrc_inverse.
+    // mj_inverse includes constraint forces from joint limits which can
+    // produce wildly incorrect torques near limit boundaries.
+    // qfrc_bias with qvel=0 gives pure gravity torques.
+    mj_forward(model_, data_);
+
+    for (int i = 0; i < ndof_; ++i) {
+        tau_out[i] = data_->qfrc_bias[i];
+    }
+}
+
+} // namespace trlc

--- a/csrc/gravity_comp.h
+++ b/csrc/gravity_comp.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <mujoco/mujoco.h>
+
+namespace trlc {
+
+class GravityCompensator {
+public:
+    GravityCompensator() = default;
+    ~GravityCompensator();
+
+    GravityCompensator(const GravityCompensator&) = delete;
+    GravityCompensator& operator=(const GravityCompensator&) = delete;
+
+    // Load model from URDF (with mesh stripping) or MJCF XML.
+    // ndof: number of arm joints to compute torques for.
+    // Returns true on success.
+    bool load(const std::string& path, int ndof = 6);
+
+    // Compute gravity compensation torques.
+    // q: input joint positions (at least ndof elements)
+    // tau_out: output torques (at least ndof elements)
+    void compute(const double* q, double* tau_out);
+
+    int ndof() const { return ndof_; }
+    bool is_loaded() const { return model_ != nullptr; }
+
+private:
+    mjModel* model_ = nullptr;
+    mjData* data_ = nullptr;
+    int ndof_ = 6;
+};
+
+} // namespace trlc

--- a/csrc/motor_defs.h
+++ b/csrc/motor_defs.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace trlc {
+
+enum class MotorType : int {
+    DM4310     = 0,
+    DM4310_48V = 1,
+    DM4340     = 2,
+    DM4340_48V = 3,
+    DM6006     = 4,
+    DM8006     = 5,
+    DM8009     = 6,
+    DM10010L   = 7,
+    DM10010    = 8,
+    DMH3510    = 9,
+    DMH6215    = 10,
+    DMG6220    = 11,
+};
+
+struct MotorLimits {
+    float q_max;
+    float dq_max;
+    float tau_max;
+};
+
+// Matches DM_CAN.py Limit_Param exactly
+inline constexpr std::array<MotorLimits, 12> MOTOR_LIMITS = {{
+    {12.5f, 30.0f,  10.0f},   // DM4310
+    {12.5f, 50.0f,  10.0f},   // DM4310_48V
+    {12.5f,  8.0f,  28.0f},   // DM4340
+    {12.5f, 10.0f,  28.0f},   // DM4340_48V
+    {12.5f, 45.0f,  20.0f},   // DM6006
+    {12.5f, 45.0f,  40.0f},   // DM8006
+    {12.5f, 45.0f,  54.0f},   // DM8009
+    {12.5f, 25.0f, 200.0f},   // DM10010L
+    {12.5f, 20.0f, 200.0f},   // DM10010
+    {12.5f, 280.0f,  1.0f},   // DMH3510
+    {12.5f, 45.0f,  10.0f},   // DMH6215
+    {12.5f, 45.0f,  10.0f},   // DMG6220
+}};
+
+inline const MotorLimits& get_limits(MotorType type) {
+    int idx = static_cast<int>(type);
+    if (idx < 0 || idx >= static_cast<int>(MOTOR_LIMITS.size())) {
+        throw std::out_of_range("Invalid MotorType index: " + std::to_string(idx));
+    }
+    return MOTOR_LIMITS[static_cast<size_t>(idx)];
+}
+
+struct MotorDescriptor {
+    std::string name;
+    MotorType type;
+    uint16_t slave_id;
+    uint16_t master_id;
+};
+
+} // namespace trlc

--- a/csrc/perf_counters.h
+++ b/csrc/perf_counters.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <time.h>
+
+namespace trlc {
+
+struct PerfSnapshot {
+    uint64_t loop_count = 0;
+    double min_cycle_us = std::numeric_limits<double>::max();
+    double max_cycle_us = 0.0;
+    double mean_cycle_us = 0.0;
+    uint64_t deadline_misses = 0;
+    std::array<uint64_t, 6> histogram = {};  // [0-100us, 100-500us, 500-1ms, 1-2ms, 2-4ms, >4ms]
+};
+
+class PerfCounters {
+public:
+    PerfCounters() = default;
+
+    // Called by RT thread each cycle
+    void record(double cycle_us, double target_us) {
+        // Handle reset request from non-RT thread (deferred to RT thread to avoid data race)
+        if (reset_requested_.load(std::memory_order_acquire)) {
+            reset_requested_.store(false, std::memory_order_relaxed);
+            stats_ = PerfSnapshot{};
+            sum_ = 0.0;
+            uint64_t s = seq_.load(std::memory_order_relaxed);
+            seq_.store(s + 1, std::memory_order_release);
+            snap_ = PerfSnapshot{};
+            seq_.store(s + 2, std::memory_order_release);
+            ring_head_.store(0, std::memory_order_release);
+            reset_ack_.fetch_add(1, std::memory_order_release);
+        }
+
+        // Update running stats
+        ++stats_.loop_count;
+        if (cycle_us < stats_.min_cycle_us) stats_.min_cycle_us = cycle_us;
+        if (cycle_us > stats_.max_cycle_us) stats_.max_cycle_us = cycle_us;
+        sum_ += cycle_us;
+        stats_.mean_cycle_us = sum_ / static_cast<double>(stats_.loop_count);
+
+        if (cycle_us > target_us * 1.5) ++stats_.deadline_misses;
+
+        // Histogram
+        int bin;
+        if (cycle_us < 100.0)       bin = 0;
+        else if (cycle_us < 500.0)  bin = 1;
+        else if (cycle_us < 1000.0) bin = 2;
+        else if (cycle_us < 2000.0) bin = 3;
+        else if (cycle_us < 4000.0) bin = 4;
+        else                        bin = 5;
+        ++stats_.histogram[static_cast<size_t>(bin)];
+
+        // Write snapshot under seqlock
+        uint64_t s = seq_.load(std::memory_order_relaxed);
+        seq_.store(s + 1, std::memory_order_release);  // odd = writing
+        snap_ = stats_;
+        seq_.store(s + 2, std::memory_order_release);  // even = done
+
+        // Write to ring buffer
+        ring_[ring_head_.load(std::memory_order_relaxed) % RING_SIZE] = static_cast<float>(cycle_us);
+        ring_head_.fetch_add(1, std::memory_order_release);
+    }
+
+    // Called from Python thread (non-blocking)
+    PerfSnapshot snapshot() const {
+        PerfSnapshot result;
+        for (int attempt = 0; attempt < 100; ++attempt) {
+            uint64_t s1 = seq_.load(std::memory_order_acquire);
+            if (s1 & 1) continue;  // writer in progress
+            result = snap_;
+            uint64_t s2 = seq_.load(std::memory_order_acquire);
+            if (s1 == s2) return result;
+        }
+        return result;  // best effort
+    }
+
+    // Copy recent cycle times into caller buffer, return count copied
+    size_t read_ring(float* out, size_t max_count) const {
+        for (int attempt = 0; attempt < 10; ++attempt) {
+            uint64_t head = ring_head_.load(std::memory_order_acquire);
+            uint64_t avail = std::min(head, static_cast<uint64_t>(RING_SIZE));
+            size_t count = std::min(static_cast<size_t>(avail), max_count);
+            uint64_t start = head - count;
+
+            for (size_t i = 0; i < count; ++i) {
+                out[i] = ring_[(start + i) % RING_SIZE];
+            }
+
+            // Verify head didn't advance too much (data wasn't overwritten)
+            uint64_t head2 = ring_head_.load(std::memory_order_acquire);
+            if (head2 - head < RING_SIZE / 2) {
+                return count;
+            }
+            // Retry if writer lapped us
+        }
+        return 0;
+    }
+
+    // Request reset (processed by RT thread on next record() call).
+    // Blocks until the RT thread has processed the reset, with a timeout.
+    // Throws std::runtime_error if the RT thread does not process the reset in time.
+    void reset(int timeout_ms = 100) {
+        uint64_t before = reset_ack_.load(std::memory_order_acquire);
+        reset_requested_.store(true, std::memory_order_release);
+        if (timeout_ms <= 0) return;  // fire-and-forget
+        for (int waited = 0; waited < timeout_ms; ++waited) {
+            if (reset_ack_.load(std::memory_order_acquire) != before) return;
+            struct timespec ts = {0, 1000000};  // 1ms
+            nanosleep(&ts, nullptr);
+        }
+        throw std::runtime_error("PerfCounters::reset() timed out waiting for RT thread acknowledgment");
+    }
+
+private:
+    // Writer-side running stats (only touched by RT thread)
+    PerfSnapshot stats_;
+    double sum_ = 0.0;
+
+    // Seqlock-protected snapshot
+    alignas(64) PerfSnapshot snap_;
+    alignas(64) std::atomic<uint64_t> seq_{0};
+
+    // Ring buffer
+    static constexpr size_t RING_SIZE = 16384;
+    alignas(64) std::array<float, RING_SIZE> ring_{};
+    alignas(64) std::atomic<uint64_t> ring_head_{0};
+
+    // Reset coordination (Python sets, RT thread consumes and acks)
+    std::atomic<bool> reset_requested_{false};
+    std::atomic<uint64_t> reset_ack_{0};
+};
+
+} // namespace trlc

--- a/csrc/rt_utils.cpp
+++ b/csrc/rt_utils.cpp
@@ -1,0 +1,137 @@
+#include "rt_utils.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+
+#include <pthread.h>
+#include <sched.h>
+#include <sys/mman.h>
+#include <sys/utsname.h>
+
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#include <mach/thread_policy.h>
+#include <mach/thread_act.h>
+#endif
+
+namespace trlc {
+
+bool detect_rt_kernel() {
+#ifdef __APPLE__
+    // macOS has no PREEMPT_RT; always return false
+    return false;
+#else
+    // Method 1: check /sys/kernel/realtime
+    {
+        std::ifstream f("/sys/kernel/realtime");
+        if (f.is_open()) {
+            int val = 0;
+            f >> val;
+            if (val == 1) return true;
+        }
+    }
+
+    // Method 2: check uname -r for PREEMPT_RT
+    {
+        struct utsname uts{};
+        if (uname(&uts) == 0) {
+            std::string release(uts.release);
+            if (release.find("PREEMPT_RT") != std::string::npos ||
+                release.find("preempt_rt") != std::string::npos) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+#endif
+}
+
+bool apply_rt_scheduling(int priority, int cpu, bool do_mlockall, double loop_hz) {
+    bool success = true;
+
+#ifdef __APPLE__
+    // Use Mach THREAD_TIME_CONSTRAINT_POLICY for real-time scheduling (no root required).
+    // This tells the scheduler we are a periodic real-time thread.
+    {
+        mach_timebase_info_data_t tb;
+        mach_timebase_info(&tb);
+        // Convert nanoseconds to mach absolute time units
+        auto ns_to_abs = [&](uint64_t ns) -> uint64_t {
+            return ns * tb.denom / tb.numer;
+        };
+
+        uint64_t period_ns = static_cast<uint64_t>(1e9 / loop_hz);
+        // Budget ~50% of period for computation, constraint = 80% of period
+        uint64_t computation_ns = period_ns / 2;
+        uint64_t constraint_ns = period_ns * 4 / 5;
+
+        thread_time_constraint_policy_data_t policy;
+        policy.period      = static_cast<uint32_t>(ns_to_abs(period_ns));
+        policy.computation = static_cast<uint32_t>(ns_to_abs(computation_ns));
+        policy.constraint  = static_cast<uint32_t>(ns_to_abs(constraint_ns));
+        policy.preemptible = 1;
+
+        kern_return_t kr = thread_policy_set(
+            pthread_mach_thread_np(pthread_self()),
+            THREAD_TIME_CONSTRAINT_POLICY,
+            reinterpret_cast<thread_policy_t>(&policy),
+            THREAD_TIME_CONSTRAINT_POLICY_COUNT);
+        if (kr != KERN_SUCCESS) {
+            std::fprintf(stderr, "rt_utils: THREAD_TIME_CONSTRAINT_POLICY failed: %d\n", kr);
+            success = false;
+        }
+    }
+
+    // CPU affinity (soft hint via affinity tags on macOS)
+    if (cpu >= 0) {
+        thread_affinity_policy_data_t affinity = { cpu + 1 };
+        kern_return_t kr = thread_policy_set(
+            pthread_mach_thread_np(pthread_self()),
+            THREAD_AFFINITY_POLICY,
+            reinterpret_cast<thread_policy_t>(&affinity),
+            THREAD_AFFINITY_POLICY_COUNT);
+        if (kr != KERN_SUCCESS) {
+            std::fprintf(stderr, "rt_utils: thread affinity tag %d failed: %d\n", cpu, kr);
+            success = false;
+        }
+    }
+#else
+    // Linux: use SCHED_FIFO for real-time priority
+    (void)loop_hz;
+    struct sched_param param{};
+    param.sched_priority = priority;
+    if (pthread_setschedparam(pthread_self(), SCHED_FIFO, &param) != 0) {
+        std::fprintf(stderr, "rt_utils: SCHED_FIFO priority %d failed: %s\n",
+                     priority, std::strerror(errno));
+        success = false;
+    }
+
+    // CPU affinity
+    if (cpu >= 0) {
+        cpu_set_t cpuset;
+        CPU_ZERO(&cpuset);
+        CPU_SET(cpu, &cpuset);
+        if (pthread_setaffinity_np(pthread_self(), sizeof(cpuset), &cpuset) != 0) {
+            std::fprintf(stderr, "rt_utils: CPU affinity to core %d failed: %s\n",
+                         cpu, std::strerror(errno));
+            success = false;
+        }
+    }
+#endif
+
+    // mlockall (available on both platforms)
+    if (do_mlockall) {
+        if (mlockall(MCL_CURRENT | MCL_FUTURE) != 0) {
+            std::fprintf(stderr, "rt_utils: mlockall failed: %s\n", std::strerror(errno));
+            success = false;
+        }
+    }
+
+    return success;
+}
+
+} // namespace trlc

--- a/csrc/rt_utils.h
+++ b/csrc/rt_utils.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+namespace trlc {
+
+// Check if running on a PREEMPT_RT kernel
+bool detect_rt_kernel();
+
+// Apply real-time scheduling. Returns true if RT was successfully applied.
+// priority: SCHED_FIFO priority (1-99, higher = more priority) [Linux]
+// cpu: CPU core to pin to (-1 = no pinning)
+// do_mlockall: lock all memory to prevent page faults
+// loop_hz: control loop frequency, used for macOS THREAD_TIME_CONSTRAINT_POLICY
+bool apply_rt_scheduling(int priority = 80, int cpu = -1, bool do_mlockall = true,
+                         double loop_hz = 250.0);
+
+} // namespace trlc

--- a/csrc/safety.h
+++ b/csrc/safety.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <algorithm>
+
+namespace trlc {
+
+struct SafetyState {
+    bool damping_mode = false;
+    int overcurrent_count = 0;
+    int overspeed_count = 0;
+};
+
+// Apply safety checks, modifying q_des, kp, and tau_ff in-place.
+// ndof: number of joints (typically 6)
+inline void apply_safety(
+    const double* pos, const double* vel, const double* torque,
+    double* q_des, double* kp, double* tau_ff,
+    const double* pos_limits_lo, const double* pos_limits_hi,
+    const double* torque_limits, const double* velocity_limits,
+    double limit_buffer,
+    int overcurrent_threshold, int overspeed_threshold,
+    int ndof,
+    SafetyState& state)
+{
+    // Position clamping with buffer
+    for (int i = 0; i < ndof; ++i) {
+        double lo = pos_limits_lo[i] + limit_buffer;
+        double hi = pos_limits_hi[i] - limit_buffer;
+        q_des[i] = std::clamp(q_des[i], lo, hi);
+    }
+
+    // Torque limit clipping
+    for (int i = 0; i < ndof; ++i) {
+        tau_ff[i] = std::clamp(tau_ff[i], -torque_limits[i], torque_limits[i]);
+    }
+
+    // Over-speed detection
+    bool any_overspeed = false;
+    for (int i = 0; i < ndof; ++i) {
+        if (std::abs(vel[i]) > velocity_limits[i]) {
+            any_overspeed = true;
+            break;
+        }
+    }
+
+    if (any_overspeed) {
+        ++state.overspeed_count;
+        if (state.overspeed_count >= overspeed_threshold) {
+            state.damping_mode = true;
+        }
+    } else {
+        state.overspeed_count = std::max(0, state.overspeed_count - 1);
+    }
+
+    // Over-current detection
+    bool any_over = false;
+    for (int i = 0; i < ndof; ++i) {
+        if (std::abs(torque[i]) > torque_limits[i]) {
+            any_over = true;
+            break;
+        }
+    }
+
+    if (any_over) {
+        ++state.overcurrent_count;
+        if (state.overcurrent_count >= overcurrent_threshold) {
+            state.damping_mode = true;
+        }
+    } else {
+        state.overcurrent_count = std::max(0, state.overcurrent_count - 1);
+    }
+
+    // In damping mode: zero stiffness and feedforward
+    if (state.damping_mode) {
+        for (int i = 0; i < ndof; ++i) {
+            kp[i] = 0.0;
+            tau_ff[i] = 0.0;
+            q_des[i] = pos[i];  // hold current position for when we exit damping
+        }
+    }
+}
+
+} // namespace trlc

--- a/csrc/serial_port.cpp
+++ b/csrc/serial_port.cpp
@@ -1,0 +1,159 @@
+#include "serial_port.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/select.h>
+#include <termios.h>
+#include <unistd.h>
+
+namespace trlc {
+
+SerialPort::~SerialPort() {
+    close();
+}
+
+bool SerialPort::open(const std::string& device, int baudrate) {
+    if (fd_ >= 0) close();
+
+    fd_ = ::open(device.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (fd_ < 0) {
+        std::fprintf(stderr, "SerialPort: cannot open %s: %s\n",
+                     device.c_str(), std::strerror(errno));
+        return false;
+    }
+
+    // Clear O_NONBLOCK after open (we want blocking writes, non-blocking reads via VMIN/VTIME)
+    int flags = fcntl(fd_, F_GETFL, 0);
+    fcntl(fd_, F_SETFL, flags & ~O_NONBLOCK);
+
+    struct termios tty{};
+    if (tcgetattr(fd_, &tty) != 0) {
+        std::fprintf(stderr, "SerialPort: tcgetattr failed: %s\n", std::strerror(errno));
+        ::close(fd_);
+        fd_ = -1;
+        return false;
+    }
+
+    // Map baudrate
+    speed_t baud;
+    switch (baudrate) {
+        case 9600:    baud = B9600;    break;
+        case 19200:   baud = B19200;   break;
+        case 38400:   baud = B38400;   break;
+        case 57600:   baud = B57600;   break;
+        case 115200:  baud = B115200;  break;
+        case 230400:  baud = B230400;  break;
+#ifdef __APPLE__
+        // macOS uses the numeric value directly for non-POSIX baud rates
+        default:      baud = static_cast<speed_t>(baudrate); break;
+#else
+        case 460800:  baud = B460800;  break;
+        case 500000:  baud = B500000;  break;
+        case 576000:  baud = B576000;  break;
+        case 921600:  baud = B921600;  break;
+        case 1000000: baud = B1000000; break;
+        default:
+            std::fprintf(stderr, "SerialPort: unsupported baudrate %d\n", baudrate);
+            ::close(fd_);
+            fd_ = -1;
+            return false;
+#endif
+    }
+
+    cfsetispeed(&tty, baud);
+    cfsetospeed(&tty, baud);
+
+    // Raw mode (8N1, no flow control)
+    cfmakeraw(&tty);
+    tty.c_cflag |= (CLOCAL | CREAD);
+    tty.c_cflag &= ~(PARENB | CSTOPB | CRTSCTS);
+    tty.c_cflag &= ~CSIZE;
+    tty.c_cflag |= CS8;
+
+    // Non-blocking read: VMIN=0, VTIME=0 -> return immediately with available data
+    tty.c_cc[VMIN] = 0;
+    tty.c_cc[VTIME] = 0;
+
+    if (tcsetattr(fd_, TCSANOW, &tty) != 0) {
+        std::fprintf(stderr, "SerialPort: tcsetattr failed: %s\n", std::strerror(errno));
+        ::close(fd_);
+        fd_ = -1;
+        return false;
+    }
+
+    // Flush any existing data
+    tcflush(fd_, TCIOFLUSH);
+
+    return true;
+}
+
+void SerialPort::close() {
+    if (fd_ >= 0) {
+        ::close(fd_);
+        fd_ = -1;
+    }
+}
+
+bool SerialPort::write(const uint8_t* buf, size_t n) {
+    if (fd_ < 0) return false;
+    size_t written = 0;
+    while (written < n) {
+        ssize_t r = ::write(fd_, buf + written, n - written);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        written += static_cast<size_t>(r);
+    }
+    return true;
+}
+
+size_t SerialPort::read_all(uint8_t* buf, size_t max) {
+    if (fd_ < 0) return 0;
+    ssize_t r = ::read(fd_, buf, max);
+    if (r < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return 0;
+        return 0;
+    }
+    return static_cast<size_t>(r);
+}
+
+size_t SerialPort::read_with_timeout(uint8_t* buf, size_t max, int timeout_us) {
+    if (fd_ < 0) return 0;
+
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(fd_, &fds);
+
+    struct timeval tv;
+    tv.tv_sec = timeout_us / 1000000;
+    tv.tv_usec = timeout_us % 1000000;
+
+    int ret = select(fd_ + 1, &fds, nullptr, nullptr, &tv);
+    if (ret <= 0) return 0;  // timeout or error
+
+    // Data available — read all that's there
+    size_t total = 0;
+    while (total < max) {
+        ssize_t r = ::read(fd_, buf + total, max - total);
+        if (r <= 0) break;
+        total += static_cast<size_t>(r);
+        // Check if more data is available without blocking
+        FD_ZERO(&fds);
+        FD_SET(fd_, &fds);
+        tv.tv_sec = 0;
+        tv.tv_usec = 0;
+        if (select(fd_ + 1, &fds, nullptr, nullptr, &tv) <= 0) break;
+    }
+    return total;
+}
+
+void SerialPort::drain() {
+    if (fd_ >= 0) {
+        tcdrain(fd_);
+    }
+}
+
+} // namespace trlc

--- a/csrc/serial_port.h
+++ b/csrc/serial_port.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace trlc {
+
+class SerialPort {
+public:
+    SerialPort() = default;
+    ~SerialPort();
+
+    SerialPort(const SerialPort&) = delete;
+    SerialPort& operator=(const SerialPort&) = delete;
+
+    bool open(const std::string& device, int baudrate = 921600);
+    void close();
+
+    // Write exactly n bytes. Returns true on success.
+    bool write(const uint8_t* buf, size_t n);
+
+    // Non-blocking read up to max bytes. Returns number of bytes read.
+    size_t read_all(uint8_t* buf, size_t max);
+
+    // Blocking read with timeout (uses select). Returns number of bytes read.
+    // Waits up to timeout_us microseconds for data to become available,
+    // then reads all available bytes.
+    size_t read_with_timeout(uint8_t* buf, size_t max, int timeout_us);
+
+    // Wait for all output to be transmitted (tcdrain wrapper).
+    void drain();
+
+    int fd() const { return fd_; }
+    bool is_open() const { return fd_ >= 0; }
+
+private:
+    int fd_ = -1;
+};
+
+} // namespace trlc

--- a/csrc/tests/test_dm_protocol.cpp
+++ b/csrc/tests/test_dm_protocol.cpp
@@ -1,0 +1,252 @@
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+#include <array>
+
+#include "dm_protocol.h"
+#include "motor_defs.h"
+
+using namespace trlc;
+
+static void test_float_to_uint_roundtrip() {
+    // Test quantization round-trip for various ranges
+    struct TestCase { float val; float min; float max; int bits; };
+    TestCase cases[] = {
+        {0.0f, -12.5f, 12.5f, 16},
+        {5.0f, -12.5f, 12.5f, 16},
+        {-5.0f, -12.5f, 12.5f, 16},
+        {12.5f, -12.5f, 12.5f, 16},
+        {-12.5f, -12.5f, 12.5f, 16},
+        {0.0f, -30.0f, 30.0f, 12},
+        {15.0f, -30.0f, 30.0f, 12},
+        {250.0f, 0.0f, 500.0f, 12},
+        {2.5f, 0.0f, 5.0f, 12},
+    };
+
+    for (const auto& tc : cases) {
+        uint16_t u = float_to_uint(tc.val, tc.min, tc.max, tc.bits);
+        float back = uint_to_float(u, tc.min, tc.max, tc.bits);
+        float span = tc.max - tc.min;
+        float tolerance = span / ((1 << tc.bits) - 1) * 1.5f;
+        assert(std::abs(back - tc.val) <= tolerance);
+    }
+    std::printf("  float_to_uint roundtrip: PASS\n");
+}
+
+static void test_float_to_uint_clamp() {
+    // Values outside range should be clamped
+    uint16_t u = float_to_uint(100.0f, -12.5f, 12.5f, 16);
+    float back = uint_to_float(u, -12.5f, 12.5f, 16);
+    assert(std::abs(back - 12.5f) < 0.01f);
+
+    u = float_to_uint(-100.0f, -12.5f, 12.5f, 16);
+    back = uint_to_float(u, -12.5f, 12.5f, 16);
+    assert(std::abs(back - (-12.5f)) < 0.01f);
+
+    std::printf("  float_to_uint clamping: PASS\n");
+}
+
+static void test_mit_frame_format() {
+    // Build a MIT frame and verify the structure
+    uint8_t frame[30];
+    MotorLimits lim = {12.5f, 8.0f, 28.0f};  // DM4340
+
+    build_mit_frame(frame, 0x01, 80.0f, 3.0f, 1.0f, 0.0f, 5.0f, lim);
+
+    // Check header bytes
+    assert(frame[0] == 0x55);
+    assert(frame[1] == 0xAA);
+    assert(frame[2] == 0x1E);  // 30 = frame length
+
+    // Check motor ID
+    assert(frame[13] == 0x01);
+    assert(frame[14] == 0x00);
+
+    // Data length marker
+    assert(frame[18] == 0x08);
+
+    // Verify we can decode back (by looking at the data bytes at offset 21)
+    const uint8_t* data = frame + 21;
+
+    // Reconstruct q
+    uint16_t q_uint = (static_cast<uint16_t>(data[0]) << 8) | data[1];
+    float q_back = uint_to_float(q_uint, -12.5f, 12.5f, 16);
+    assert(std::abs(q_back - 1.0f) < 0.01f);
+
+    // Reconstruct dq
+    uint16_t dq_uint = (static_cast<uint16_t>(data[2]) << 4) | (data[3] >> 4);
+    float dq_back = uint_to_float(dq_uint, -8.0f, 8.0f, 12);
+    assert(std::abs(dq_back - 0.0f) < 0.05f);
+
+    // Reconstruct kp
+    uint16_t kp_uint = ((data[3] & 0x0F) << 8) | data[4];
+    float kp_back = uint_to_float(kp_uint, 0.0f, 500.0f, 12);
+    assert(std::abs(kp_back - 80.0f) < 1.0f);
+
+    // Reconstruct kd
+    uint16_t kd_uint = (static_cast<uint16_t>(data[5]) << 4) | (data[6] >> 4);
+    float kd_back = uint_to_float(kd_uint, 0.0f, 5.0f, 12);
+    assert(std::abs(kd_back - 3.0f) < 0.01f);
+
+    // Reconstruct tau
+    uint16_t tau_uint = ((data[6] & 0x0F) << 8) | data[7];
+    float tau_back = uint_to_float(tau_uint, -28.0f, 28.0f, 12);
+    assert(std::abs(tau_back - 5.0f) < 0.1f);
+
+    std::printf("  MIT frame format: PASS\n");
+}
+
+static void test_emit_frame_format() {
+    uint8_t frame[30];
+    build_emit_frame(frame, 0x07, -2.35f, 3000.0f, 1058.0f);
+
+    // Motor ID should be 0x307
+    assert(frame[13] == 0x07);
+    assert(frame[14] == 0x03);
+
+    // Position is IEEE 754 float at offset 21
+    float pos;
+    std::memcpy(&pos, frame + 21, 4);
+    assert(std::abs(pos - (-2.35f)) < 0.001f);
+
+    // Velocity at offset 25 (little-endian uint16)
+    uint16_t vel = frame[25] | (static_cast<uint16_t>(frame[26]) << 8);
+    assert(vel == 3000);
+
+    // Current at offset 27 (little-endian uint16)
+    uint16_t ides = frame[27] | (static_cast<uint16_t>(frame[28]) << 8);
+    assert(ides == 1058);
+
+    std::printf("  EMIT frame format: PASS\n");
+}
+
+static void test_enable_disable_frames() {
+    uint8_t frame[30];
+
+    build_enable_frame(frame, 0x05);
+    assert(frame[13] == 0x05);
+    assert(frame[28] == 0xFC);  // enable command byte in data[7]
+
+    build_disable_frame(frame, 0x05);
+    assert(frame[28] == 0xFD);
+
+    build_set_zero_frame(frame, 0x05);
+    assert(frame[28] == 0xFE);
+
+    std::printf("  enable/disable/set-zero frames: PASS\n");
+}
+
+static void test_refresh_frame() {
+    uint8_t frame[30];
+    build_refresh_frame(frame, 0x03);
+
+    // CAN ID should be 0x7FF
+    assert(frame[13] == 0xFF);
+    assert(frame[14] == 0x07);
+
+    // Data: slave_id_lo, slave_id_hi, 0xCC, ...
+    assert(frame[21] == 0x03);
+    assert(frame[22] == 0x00);
+    assert(frame[23] == 0xCC);
+
+    std::printf("  refresh frame: PASS\n");
+}
+
+static void test_switch_mode_frame() {
+    uint8_t frame[30];
+    build_switch_mode_frame(frame, 0x04, 1);  // MIT mode
+
+    assert(frame[13] == 0xFF);
+    assert(frame[14] == 0x07);
+    assert(frame[21] == 0x04);  // slave_id
+    assert(frame[23] == 0x55);  // write command
+    assert(frame[24] == 10);    // RID = CTRL_MODE
+    assert(frame[25] == 1);     // mode value
+
+    std::printf("  switch mode frame: PASS\n");
+}
+
+static void test_packet_parser() {
+    PacketParser parser;
+
+    // Build a fake 16-byte receive packet
+    uint8_t pkt[16] = {};
+    pkt[0] = 0xAA;   // header
+    pkt[15] = 0x55;  // tail
+    pkt[1] = 0x11;   // CMD
+    pkt[3] = 0x01;   // CAN ID low byte (slave_id=1)
+
+    // Set motor state data at bytes 7-12
+    // q = 0 -> q_uint = 32768 (midpoint for 16-bit with [-12.5, 12.5])
+    uint16_t q_uint = 32768;  // approximately 0.0
+    pkt[8] = (q_uint >> 8) & 0xFF;
+    pkt[9] = q_uint & 0xFF;
+    // dq and tau at midpoint too
+    uint16_t dq_uint = 2048;
+    pkt[10] = dq_uint >> 4;
+    pkt[11] = (dq_uint & 0x0F) << 4;
+    uint16_t tau_uint = 2048;
+    pkt[11] |= (tau_uint >> 8) & 0x0F;
+    pkt[12] = tau_uint & 0xFF;
+
+    // Feed packet with some garbage before it
+    uint8_t garbage[] = {0x12, 0x34, 0x56};
+    parser.feed(garbage, 3);
+    parser.feed(pkt, 16);
+
+    // Also add a second packet
+    pkt[3] = 0x02;  // different CAN ID
+    parser.feed(pkt, 16);
+
+    std::vector<std::array<uint8_t, 16>> packets;
+    size_t count = parser.extract(packets);
+    assert(count == 2);
+    assert(packets[0][3] == 0x01);
+    assert(packets[1][3] == 0x02);
+
+    // Decode state from first packet
+    MotorLimits lim = {12.5f, 30.0f, 10.0f};  // DM4310
+    auto state = decode_motor_state(packets[0].data(), lim);
+    assert(std::abs(state.q) < 0.01f);  // should be close to 0
+
+    std::printf("  packet parser: PASS\n");
+}
+
+static void test_partial_packet() {
+    PacketParser parser;
+
+    uint8_t pkt[16] = {};
+    pkt[0] = 0xAA;
+    pkt[15] = 0x55;
+    pkt[1] = 0x11;
+
+    // Feed first half
+    parser.feed(pkt, 8);
+    std::vector<std::array<uint8_t, 16>> packets;
+    size_t count = parser.extract(packets);
+    assert(count == 0);
+
+    // Feed second half
+    parser.feed(pkt + 8, 8);
+    count = parser.extract(packets);
+    assert(count == 1);
+
+    std::printf("  partial packet reassembly: PASS\n");
+}
+
+int main() {
+    std::printf("dm_protocol tests:\n");
+    test_float_to_uint_roundtrip();
+    test_float_to_uint_clamp();
+    test_mit_frame_format();
+    test_emit_frame_format();
+    test_enable_disable_frames();
+    test_refresh_frame();
+    test_switch_mode_frame();
+    test_packet_parser();
+    test_partial_packet();
+    std::printf("All dm_protocol tests passed!\n");
+    return 0;
+}

--- a/csrc/tests/test_perf_counters.cpp
+++ b/csrc/tests/test_perf_counters.cpp
@@ -1,0 +1,165 @@
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <thread>
+#include <vector>
+#include <atomic>
+
+#include "perf_counters.h"
+
+using namespace trlc;
+
+static void test_basic_recording() {
+    PerfCounters pc;
+
+    pc.record(100.0, 4000.0);
+    pc.record(200.0, 4000.0);
+    pc.record(300.0, 4000.0);
+
+    auto snap = pc.snapshot();
+    assert(snap.loop_count == 3);
+    assert(std::abs(snap.min_cycle_us - 100.0) < 0.01);
+    assert(std::abs(snap.max_cycle_us - 300.0) < 0.01);
+    assert(std::abs(snap.mean_cycle_us - 200.0) < 0.01);
+    assert(snap.deadline_misses == 0);  // none exceed 6000us
+
+    std::printf("  basic recording: PASS\n");
+}
+
+static void test_deadline_miss() {
+    PerfCounters pc;
+
+    pc.record(100.0, 4000.0);
+    pc.record(7000.0, 4000.0);  // > 6000 = 1.5x target
+
+    auto snap = pc.snapshot();
+    assert(snap.deadline_misses == 1);
+
+    std::printf("  deadline miss: PASS\n");
+}
+
+static void test_histogram() {
+    PerfCounters pc;
+
+    pc.record(50.0, 4000.0);     // bin 0: 0-100us
+    pc.record(250.0, 4000.0);    // bin 1: 100-500us
+    pc.record(750.0, 4000.0);    // bin 2: 500-1ms
+    pc.record(1500.0, 4000.0);   // bin 3: 1-2ms
+    pc.record(3000.0, 4000.0);   // bin 4: 2-4ms
+    pc.record(5000.0, 4000.0);   // bin 5: >4ms
+
+    auto snap = pc.snapshot();
+    assert(snap.histogram[0] == 1);
+    assert(snap.histogram[1] == 1);
+    assert(snap.histogram[2] == 1);
+    assert(snap.histogram[3] == 1);
+    assert(snap.histogram[4] == 1);
+    assert(snap.histogram[5] == 1);
+
+    std::printf("  histogram: PASS\n");
+}
+
+static void test_ring_buffer() {
+    PerfCounters pc;
+
+    for (int i = 0; i < 100; ++i) {
+        pc.record(static_cast<double>(i), 4000.0);
+    }
+
+    float buf[200];
+    size_t n = pc.read_ring(buf, 200);
+    assert(n == 100);
+
+    // Last element should be 99
+    assert(std::abs(buf[n - 1] - 99.0f) < 0.01f);
+    // First element should be 0
+    assert(std::abs(buf[0] - 0.0f) < 0.01f);
+
+    std::printf("  ring buffer: PASS\n");
+}
+
+static void test_ring_buffer_overflow() {
+    PerfCounters pc;
+
+    // Write more than RING_SIZE entries
+    for (int i = 0; i < 20000; ++i) {
+        pc.record(static_cast<double>(i), 4000.0);
+    }
+
+    float buf[16384];
+    size_t n = pc.read_ring(buf, 16384);
+    assert(n == 16384);
+
+    // Last entry should be 19999
+    assert(std::abs(buf[n - 1] - 19999.0f) < 0.01f);
+
+    std::printf("  ring buffer overflow: PASS\n");
+}
+
+static void test_concurrent_access() {
+    PerfCounters pc;
+    std::atomic<bool> running{true};
+    constexpr int NUM_WRITES = 100000;
+
+    // Writer thread (simulates RT thread)
+    std::thread writer([&]() {
+        for (int i = 0; i < NUM_WRITES; ++i) {
+            pc.record(static_cast<double>(i % 4000), 4000.0);
+        }
+        running.store(false);
+    });
+
+    // Reader thread (simulates Python thread)
+    int read_count = 0;
+    while (running.load()) {
+        auto snap = pc.snapshot();
+        (void)snap;
+
+        float buf[100];
+        pc.read_ring(buf, 100);
+
+        ++read_count;
+    }
+
+    writer.join();
+
+    auto snap = pc.snapshot();
+    assert(snap.loop_count == NUM_WRITES);
+    assert(read_count > 0);
+
+    std::printf("  concurrent access (%d reads during %d writes): PASS\n",
+                read_count, NUM_WRITES);
+}
+
+static void test_reset() {
+    PerfCounters pc;
+
+    pc.record(100.0, 4000.0);
+    pc.record(200.0, 4000.0);
+
+    pc.reset(0);  // non-blocking (no RT thread in unit test)
+    // Reset is deferred — the next record() call processes it, then records
+    pc.record(50.0, 4000.0);
+
+    auto snap = pc.snapshot();
+    // After reset + one new record: loop_count=1, min=50, max=50
+    assert(snap.loop_count == 1);
+    assert(snap.deadline_misses == 0);
+    assert(std::abs(snap.min_cycle_us - 50.0) < 0.01);
+    assert(std::abs(snap.max_cycle_us - 50.0) < 0.01);
+
+    std::printf("  reset: PASS\n");
+}
+
+int main() {
+    std::printf("perf_counters tests:\n");
+    test_basic_recording();
+    test_deadline_miss();
+    test_histogram();
+    test_ring_buffer();
+    test_ring_buffer_overflow();
+    test_concurrent_access();
+    test_reset();
+    std::printf("All perf_counters tests passed!\n");
+    return 0;
+}

--- a/lerobot_robot_trlc_dk1/bi_follower.py
+++ b/lerobot_robot_trlc_dk1/bi_follower.py
@@ -59,19 +59,14 @@ class BiDK1Follower(Robot):
 
         self.config = config
 
-        # Option C alignment toggle. Default ON; set LEROBOT_OBS_ALIGN=0 in the
-        # environment to disable and fall back to "latest of everything per
-        # tick" semantics (matches upstream LeRobot behaviour but produces noisy
-        # labels under rate-aliasing and transient stalls). See SPEC.md for the
-        # trade-off analysis.
-        _align_env = os.environ.get("LEROBOT_OBS_ALIGN", "1").strip().lower()
-        self._align_observations = _align_env not in ("0", "false", "no", "off")
-        if not self._align_observations:
-            logger.warning(
-                "BiDK1Follower: LEROBOT_OBS_ALIGN=%r — Option C alignment DISABLED; "
-                "observations will use latest-of-everything semantics.",
-                _align_env,
-            )
+        # Observation-alignment toggle. Default OFF (matches upstream LeRobot
+        # "latest-of-everything-per-tick" semantics). Set LEROBOT_OBS_ALIGN=1 in
+        # the environment to instead pick a reference time T (= newest camera
+        # kernel capture timestamp) and source motor + leader state from T, so
+        # every dataset row contains a self-consistent (image, motors, action)
+        # triple at the cost of one camera period of inherent latency.
+        _align_env = os.environ.get("LEROBOT_OBS_ALIGN", "0").strip().lower()
+        self._align_observations = _align_env in ("1", "true", "yes", "on")
 
         left_arm_config = DK1FollowerConfig(
             port=self.config.left_arm_port,
@@ -178,22 +173,22 @@ class BiDK1Follower(Robot):
         }
 
     def get_observation(self) -> dict[str, Any]:
-        """Return a single dict of all sensors, aligned in time when possible.
+        """Return a single dict of all sensors, optionally time-aligned.
 
-        Option C: when every bi-follower camera exposes ``latest_capture_time_ns``
-        (true for the cpp backend, false for opencv), we pick a reference time
-        ``T`` = the newest camera frame's kernel capture timestamp and ask every
-        other sensor — motors via the RT loop's state ring, per-arm cameras —
-        for state at-or-before ``T``. The dataset row therefore contains a
-        physically-self-consistent snapshot from ~1 camera period in the past,
-        instead of "latest of everything at tick time" (which can drift apart
-        during Python catch-up).
+        When ``self._align_observations`` is True *and* every bi-follower
+        camera exposes ``latest_capture_time_ns`` (true for the cpp backend,
+        false for opencv), we pick a reference time ``T`` = the newest camera
+        frame's kernel capture timestamp and ask every other sensor — motors
+        via the RT loop's state ring, per-arm cameras — for state at-or-before
+        ``T``. The dataset row then contains a self-consistent snapshot from
+        ~1 camera period in the past, instead of "latest of everything at tick
+        time" (which can drift apart during Python catch-up).
 
         The chosen ``T`` is stashed on ``self._last_observation_ref_ts_ns`` so
         the recording loop can use it to align the leader teleop snapshot too.
 
-        When alignment isn't available (e.g. CAM_BACKEND=opencv), falls back
-        to the legacy latest semantics.
+        When alignment is disabled, or when a camera doesn't carry kernel
+        timestamps, falls back to legacy latest semantics on every read.
         """
         # Pick the reference time T — newest camera kernel capture timestamp
         # across all bi-follower cameras. If any camera lacks the API or has

--- a/lerobot_robot_trlc_dk1/bi_follower.py
+++ b/lerobot_robot_trlc_dk1/bi_follower.py
@@ -125,9 +125,19 @@ class BiDK1Follower(Robot):
         self.left_arm.configure()
         self.right_arm.configure()
 
+    def get_joint_torques(self) -> dict[str, float]:
+        """Per-arm torque side-channel for haptic feedback. Mirrors
+        ``DK1Follower.get_joint_torques`` with ``left_/right_`` prefixes."""
+        out: dict[str, float] = {}
+        for key, val in self.left_arm.get_joint_torques().items():
+            out[f"left_{key}"] = val
+        for key, val in self.right_arm.get_joint_torques().items():
+            out[f"right_{key}"] = val
+        return out
+
     def get_observation(self) -> dict[str, Any]:
         obs_dict = {}
-        
+
         left_obs = self.left_arm.get_observation()
         obs_dict.update({f"left_{key}": value for key, value in left_obs.items()})
 

--- a/lerobot_robot_trlc_dk1/bi_follower.py
+++ b/lerobot_robot_trlc_dk1/bi_follower.py
@@ -135,6 +135,33 @@ class BiDK1Follower(Robot):
             out[f"right_{key}"] = val
         return out
 
+    # Stats for diagnostics (read by lerobot_record to surface in status line
+    # or end-of-episode summary). All counters are reset on connect().
+    _stats_total_obs: int = 0
+    _stats_obs_aligned: int = 0          # ref_ts_ns was determinable
+    _stats_obs_ref_unchanged: int = 0    # same ref_ts_ns as previous obs (= duplicate)
+    _stats_prev_ref_ts_ns: int | None = None
+
+    def get_observation_stats(self) -> dict[str, int | float]:
+        """Return cumulative observation-assembly stats since connect().
+
+        Useful for detecting frame-rate aliasing duplicates: when
+        ``ref_unchanged`` / ``total`` is non-trivial, the record loop is
+        firing faster than the cameras produce new frames, so consecutive
+        ticks read the same reference time → same image, motors, action →
+        a duplicate row.
+        """
+        return {
+            "total": self._stats_total_obs,
+            "aligned": self._stats_obs_aligned,
+            "ref_unchanged": self._stats_obs_ref_unchanged,
+            "ref_unchanged_pct": (
+                100.0 * self._stats_obs_ref_unchanged / self._stats_total_obs
+                if self._stats_total_obs > 0
+                else 0.0
+            ),
+        }
+
     def get_observation(self) -> dict[str, Any]:
         """Return a single dict of all sensors, aligned in time when possible.
 
@@ -174,6 +201,29 @@ class BiDK1Follower(Robot):
         # Expose to callers (e.g. the recording loop) so they can align the
         # leader teleop snapshot to the same T.
         self._last_observation_ref_ts_ns = ref_ts_ns
+
+        # Update stats — track whether ref_ts_ns changed since last obs. A
+        # streak of unchanged refs means consecutive ticks read the same
+        # frame/motors/action triple → those rows are duplicates in the
+        # dataset, almost always caused by 50 Hz loop vs 50 fps camera
+        # rate aliasing (not by a logic bug).
+        self._stats_total_obs += 1
+        if ref_ts_ns is not None:
+            self._stats_obs_aligned += 1
+            if (
+                self._stats_prev_ref_ts_ns is not None
+                and ref_ts_ns == self._stats_prev_ref_ts_ns
+            ):
+                self._stats_obs_ref_unchanged += 1
+            self._stats_prev_ref_ts_ns = ref_ts_ns
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "bi_follower obs: ref_ts_ns=%s cams=%s prev=%s "
+                "(total=%d, aligned=%d, ref_unchanged=%d)",
+                ref_ts_ns, cam_ts, self._stats_prev_ref_ts_ns,
+                self._stats_total_obs, self._stats_obs_aligned,
+                self._stats_obs_ref_unchanged,
+            )
 
         obs_dict: dict[str, Any] = {}
 

--- a/lerobot_robot_trlc_dk1/bi_follower.py
+++ b/lerobot_robot_trlc_dk1/bi_follower.py
@@ -136,24 +136,77 @@ class BiDK1Follower(Robot):
         return out
 
     def get_observation(self) -> dict[str, Any]:
-        obs_dict = {}
+        """Return a single dict of all sensors, aligned in time when possible.
 
-        left_obs = self.left_arm.get_observation()
+        Option C: when every bi-follower camera exposes ``latest_capture_time_ns``
+        (true for the cpp backend, false for opencv), we pick a reference time
+        ``T`` = the newest camera frame's kernel capture timestamp and ask every
+        other sensor — motors via the RT loop's state ring, per-arm cameras —
+        for state at-or-before ``T``. The dataset row therefore contains a
+        physically-self-consistent snapshot from ~1 camera period in the past,
+        instead of "latest of everything at tick time" (which can drift apart
+        during Python catch-up).
+
+        The chosen ``T`` is stashed on ``self._last_observation_ref_ts_ns`` so
+        the recording loop can use it to align the leader teleop snapshot too.
+
+        When alignment isn't available (e.g. CAM_BACKEND=opencv), falls back
+        to the legacy latest semantics.
+        """
+        # Pick the reference time T — newest camera kernel capture timestamp
+        # across all bi-follower cameras. If any camera lacks the API or has
+        # never produced a frame, fall back to latest-of-everything.
+        ref_ts_ns: int | None = None
+        cam_ts: list[int] = []
+        for cam in self.cameras.values():
+            get_ts = getattr(cam, "latest_capture_time_ns", None)
+            if get_ts is None:
+                cam_ts = []
+                break
+            ts = get_ts()
+            if ts is None:
+                cam_ts = []
+                break
+            cam_ts.append(ts)
+        if cam_ts:
+            ref_ts_ns = max(cam_ts)
+
+        # Expose to callers (e.g. the recording loop) so they can align the
+        # leader teleop snapshot to the same T.
+        self._last_observation_ref_ts_ns = ref_ts_ns
+
+        obs_dict: dict[str, Any] = {}
+
+        left_obs = self.left_arm.get_observation(ref_ts_ns=ref_ts_ns)
         obs_dict.update({f"left_{key}": value for key, value in left_obs.items()})
 
-        right_obs = self.right_arm.get_observation()
+        right_obs = self.right_arm.get_observation(ref_ts_ns=ref_ts_ns)
         obs_dict.update({f"right_{key}": value for key, value in right_obs.items()})
 
         for cam_key, cam in self.cameras.items():
             start = time.perf_counter()
-            # Use read_latest() to avoid blocking when loop runs faster than camera FPS.
-            # This returns the most recent frame immediately (~0ms) instead of waiting
-            # for a new frame (~33ms at 30fps). Critical for 50fps dataset with 30fps cameras.
-            obs_dict[cam_key] = cam.read_latest()
+            frame = None
+            if ref_ts_ns is not None and hasattr(cam, "read_at_or_before"):
+                frame = cam.read_at_or_before(ref_ts_ns)
+            if frame is None:
+                # Fallback: legacy non-blocking latest read.
+                frame = cam.read_latest()
+            obs_dict[cam_key] = frame
             dt_ms = (time.perf_counter() - start) * 1e3
             logger.debug(f"{self} read {cam_key}: {dt_ms:.1f}ms")
 
         return obs_dict
+
+    @property
+    def last_observation_ref_ts_ns(self) -> int | None:
+        """Reference time used by the most recent ``get_observation()``.
+
+        ``None`` if no observation has been taken yet, or if the cameras
+        don't support timestamp alignment (legacy / opencv backend). Used
+        by the recording loop to align the leader teleop snapshot to the
+        same T the rest of the observation was assembled from.
+        """
+        return getattr(self, "_last_observation_ref_ts_ns", None)
 
     def send_action(self, action: dict[str, Any]) -> dict[str, Any]:
         left_action = {

--- a/lerobot_robot_trlc_dk1/bi_follower.py
+++ b/lerobot_robot_trlc_dk1/bi_follower.py
@@ -148,9 +148,15 @@ class BiDK1Follower(Robot):
     # Stats for diagnostics (read by lerobot_record to surface in status line
     # or end-of-episode summary). All counters are reset on connect().
     _stats_total_obs: int = 0
-    _stats_obs_aligned: int = 0          # ref_ts_ns was determinable
-    _stats_obs_ref_unchanged: int = 0    # same ref_ts_ns as previous obs (= duplicate)
-    _stats_prev_ref_ts_ns: int | None = None
+    # Counts observations where the cpp camera backend gave us a kernel
+    # capture timestamp (regardless of whether OBS_ALIGN was on).
+    _stats_obs_aligned: int = 0
+    # Counts observations whose cam_capture_ts_ns equalled the previous obs's
+    # — i.e. the recording loop fired twice between two camera frames, so
+    # this row's image is a duplicate of the previous row's image (rate-
+    # aliasing). The ground-truth duplicate count for the dataset.
+    _stats_obs_ref_unchanged: int = 0
+    _stats_prev_cam_ts_ns: int | None = None
 
     def get_observation_stats(self) -> dict[str, int | float]:
         """Return cumulative observation-assembly stats since connect().
@@ -190,51 +196,59 @@ class BiDK1Follower(Robot):
         When alignment is disabled, or when a camera doesn't carry kernel
         timestamps, falls back to legacy latest semantics on every read.
         """
-        # Pick the reference time T — newest camera kernel capture timestamp
-        # across all bi-follower cameras. If any camera lacks the API or has
-        # never produced a frame, fall back to latest-of-everything.
-        ref_ts_ns: int | None = None
+        # Poll the newest camera kernel capture timestamp across all bi-follower
+        # cameras. We do this UNCONDITIONALLY (whenever the cpp backend is in
+        # use) so we can record it in the timing side-file for diagnostics —
+        # image staleness, rate-aliasing duplicates, image-vs-action skew all
+        # work without needing alignment to be on. If any camera lacks the API
+        # (e.g. opencv backend) or hasn't produced a frame yet, the list is
+        # discarded and cam_capture_ts_ns stays None.
         cam_ts: list[int] = []
-        if self._align_observations:
-            for cam in self.cameras.values():
-                get_ts = getattr(cam, "latest_capture_time_ns", None)
-                if get_ts is None:
-                    cam_ts = []
-                    break
-                ts = get_ts()
-                if ts is None:
-                    cam_ts = []
-                    break
-                cam_ts.append(ts)
-            if cam_ts:
-                ref_ts_ns = max(cam_ts)
-        # If _align_observations is False, ref_ts_ns stays None — every
-        # downstream call (per-arm get_observation, cam.read_at_or_before)
-        # already handles None as "use legacy latest semantics".
+        for cam in self.cameras.values():
+            get_ts = getattr(cam, "latest_capture_time_ns", None)
+            if get_ts is None:
+                cam_ts = []
+                break
+            ts = get_ts()
+            if ts is None:
+                cam_ts = []
+                break
+            cam_ts.append(ts)
+        cam_capture_ts_ns: int | None = max(cam_ts) if cam_ts else None
 
-        # Expose to callers (e.g. the recording loop) so they can align the
-        # leader teleop snapshot to the same T.
+        # Alignment is a SEPARATE decision from "do we know the camera ts".
+        # When _align_observations is True and a cam ts is available, use it
+        # as the reference time T that motors / leader / per-cam reads will be
+        # sampled at. Otherwise downstream code paths fall back to "latest
+        # of everything" via the None sentinel.
+        ref_ts_ns: int | None = cam_capture_ts_ns if self._align_observations else None
+
+        # Expose both: ref_ts_ns is the *applied* reference (used by the record
+        # loop to align the teleop snapshot); cam_capture_ts_ns is the
+        # *observed* camera ts at this tick (used by the timing side-file
+        # diagnostics regardless of whether alignment was on).
         self._last_observation_ref_ts_ns = ref_ts_ns
+        self._last_camera_capture_ts_ns = cam_capture_ts_ns
 
-        # Update stats — track whether ref_ts_ns changed since last obs. A
-        # streak of unchanged refs means consecutive ticks read the same
-        # frame/motors/action triple → those rows are duplicates in the
-        # dataset, almost always caused by 50 Hz loop vs 50 fps camera
-        # rate aliasing (not by a logic bug).
+        # Update stats — track whether the camera ts changed since last obs.
+        # A streak of unchanged values means consecutive ticks read the same
+        # camera frame → those rows are rate-aliasing duplicates (image-side).
+        # This is the ground truth for the dashboard's "Duplicate Frames" card
+        # and is meaningful whether alignment is on or off.
         self._stats_total_obs += 1
-        if ref_ts_ns is not None:
+        if cam_capture_ts_ns is not None:
             self._stats_obs_aligned += 1
             if (
-                self._stats_prev_ref_ts_ns is not None
-                and ref_ts_ns == self._stats_prev_ref_ts_ns
+                self._stats_prev_cam_ts_ns is not None
+                and cam_capture_ts_ns == self._stats_prev_cam_ts_ns
             ):
                 self._stats_obs_ref_unchanged += 1
-            self._stats_prev_ref_ts_ns = ref_ts_ns
+            self._stats_prev_cam_ts_ns = cam_capture_ts_ns
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                "bi_follower obs: ref_ts_ns=%s cams=%s prev=%s "
-                "(total=%d, aligned=%d, ref_unchanged=%d)",
-                ref_ts_ns, cam_ts, self._stats_prev_ref_ts_ns,
+                "bi_follower obs: cam_ts=%s ref_ts=%s prev_cam=%s "
+                "(total=%d, with_cam_ts=%d, cam_unchanged=%d)",
+                cam_capture_ts_ns, ref_ts_ns, self._stats_prev_cam_ts_ns,
                 self._stats_total_obs, self._stats_obs_aligned,
                 self._stats_obs_ref_unchanged,
             )
@@ -263,14 +277,31 @@ class BiDK1Follower(Robot):
 
     @property
     def last_observation_ref_ts_ns(self) -> int | None:
-        """Reference time used by the most recent ``get_observation()``.
+        """Reference time *used* by the most recent ``get_observation()``.
 
-        ``None`` if no observation has been taken yet, or if the cameras
-        don't support timestamp alignment (legacy / opencv backend). Used
-        by the recording loop to align the leader teleop snapshot to the
-        same T the rest of the observation was assembled from.
+        ``None`` when alignment is disabled (``OBS_ALIGN=0``) or unavailable
+        (e.g. opencv backend). Used by the recording loop to align the leader
+        teleop snapshot to the same T that the rest of the observation was
+        assembled from.
+
+        See ``last_camera_capture_ts_ns`` for the camera timestamp that's
+        always tracked when the cpp backend is in use, regardless of whether
+        alignment was actually applied.
         """
         return getattr(self, "_last_observation_ref_ts_ns", None)
+
+    @property
+    def last_camera_capture_ts_ns(self) -> int | None:
+        """Newest camera kernel capture timestamp observed at the most recent
+        ``get_observation()``, regardless of the alignment toggle.
+
+        ``None`` only if the cameras don't expose ``latest_capture_time_ns``
+        (i.e. the opencv backend) or none have produced a frame yet. The
+        recording loop writes this to the timing side-file so the dashboard
+        can compute image-staleness and rate-aliasing duplicates without
+        decoding any video, even when ``OBS_ALIGN=0``.
+        """
+        return getattr(self, "_last_camera_capture_ts_ns", None)
 
     def send_action(self, action: dict[str, Any]) -> dict[str, Any]:
         left_action = {

--- a/lerobot_robot_trlc_dk1/bi_follower.py
+++ b/lerobot_robot_trlc_dk1/bi_follower.py
@@ -14,6 +14,7 @@
 
 from dataclasses import dataclass, field
 from functools import cached_property
+import os
 import time
 import logging
 from typing import Any
@@ -57,7 +58,21 @@ class BiDK1Follower(Robot):
         super().__init__(config)
 
         self.config = config
-        
+
+        # Option C alignment toggle. Default ON; set LEROBOT_OBS_ALIGN=0 in the
+        # environment to disable and fall back to "latest of everything per
+        # tick" semantics (matches upstream LeRobot behaviour but produces noisy
+        # labels under rate-aliasing and transient stalls). See SPEC.md for the
+        # trade-off analysis.
+        _align_env = os.environ.get("LEROBOT_OBS_ALIGN", "1").strip().lower()
+        self._align_observations = _align_env not in ("0", "false", "no", "off")
+        if not self._align_observations:
+            logger.warning(
+                "BiDK1Follower: LEROBOT_OBS_ALIGN=%r — Option C alignment DISABLED; "
+                "observations will use latest-of-everything semantics.",
+                _align_env,
+            )
+
         left_arm_config = DK1FollowerConfig(
             port=self.config.left_arm_port,
             disable_torque_on_disconnect=self.config.disable_torque_on_disconnect,
@@ -185,18 +200,22 @@ class BiDK1Follower(Robot):
         # never produced a frame, fall back to latest-of-everything.
         ref_ts_ns: int | None = None
         cam_ts: list[int] = []
-        for cam in self.cameras.values():
-            get_ts = getattr(cam, "latest_capture_time_ns", None)
-            if get_ts is None:
-                cam_ts = []
-                break
-            ts = get_ts()
-            if ts is None:
-                cam_ts = []
-                break
-            cam_ts.append(ts)
-        if cam_ts:
-            ref_ts_ns = max(cam_ts)
+        if self._align_observations:
+            for cam in self.cameras.values():
+                get_ts = getattr(cam, "latest_capture_time_ns", None)
+                if get_ts is None:
+                    cam_ts = []
+                    break
+                ts = get_ts()
+                if ts is None:
+                    cam_ts = []
+                    break
+                cam_ts.append(ts)
+            if cam_ts:
+                ref_ts_ns = max(cam_ts)
+        # If _align_observations is False, ref_ts_ns stays None — every
+        # downstream call (per-arm get_observation, cam.read_at_or_before)
+        # already handles None as "use legacy latest semantics".
 
         # Expose to callers (e.g. the recording loop) so they can align the
         # leader teleop snapshot to the same T.

--- a/lerobot_robot_trlc_dk1/bi_follower.py
+++ b/lerobot_robot_trlc_dk1/bi_follower.py
@@ -26,7 +26,6 @@ from lerobot_robot_trlc_dk1.motors.DM_Control_Python.DM_CAN import *
 from lerobot_robot_trlc_dk1.follower import DK1Follower, DK1FollowerConfig
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 def map_range(x: float, in_min: float, in_max: float, out_min: float, out_max: float) -> float:
@@ -42,6 +41,8 @@ class BiDK1FollowerConfig(RobotConfig):
     joint_velocity_scaling: float = 0.2
     max_gripper_torque: float = 1.0 # Nm (/0.00875m spur gear radius = 114N gripper force)
     cameras: dict[str, CameraConfig] = field(default_factory=dict)
+    # Control mode: "pos_vel" (Python serial) or "rt_impedance" (C++ RT loop at 250Hz)
+    control_mode: str = "rt_impedance"
 
 
 class BiDK1Follower(Robot):
@@ -62,12 +63,14 @@ class BiDK1Follower(Robot):
             disable_torque_on_disconnect=self.config.disable_torque_on_disconnect,
             joint_velocity_scaling=self.config.joint_velocity_scaling,
             max_gripper_torque=self.config.max_gripper_torque,
+            control_mode=self.config.control_mode,
         )
         right_arm_config = DK1FollowerConfig(
             port=self.config.right_arm_port,
             disable_torque_on_disconnect=self.config.disable_torque_on_disconnect,
             joint_velocity_scaling=self.config.joint_velocity_scaling,
             max_gripper_torque=self.config.max_gripper_torque,
+            control_mode=self.config.control_mode,
         )
         
         self.left_arm = DK1Follower(left_arm_config)
@@ -102,8 +105,14 @@ class BiDK1Follower(Robot):
         self.left_arm.connect()
         self.right_arm.connect()
 
-        for cam in self.cameras.values():
-            cam.connect()
+        try:
+            for cam in self.cameras.values():
+                cam.connect()
+        except Exception:
+            # Clean up RT loops if camera connection fails
+            self.left_arm.disconnect()
+            self.right_arm.disconnect()
+            raise
 
     @property
     def is_calibrated(self) -> bool:
@@ -127,7 +136,10 @@ class BiDK1Follower(Robot):
 
         for cam_key, cam in self.cameras.items():
             start = time.perf_counter()
-            obs_dict[cam_key] = cam.async_read()
+            # Use read_latest() to avoid blocking when loop runs faster than camera FPS.
+            # This returns the most recent frame immediately (~0ms) instead of waiting
+            # for a new frame (~33ms at 30fps). Critical for 50fps dataset with 30fps cameras.
+            obs_dict[cam_key] = cam.read_latest()
             dt_ms = (time.perf_counter() - start) * 1e3
             logger.debug(f"{self} read {cam_key}: {dt_ms:.1f}ms")
 

--- a/lerobot_robot_trlc_dk1/follower.py
+++ b/lerobot_robot_trlc_dk1/follower.py
@@ -140,11 +140,15 @@ class DK1Follower(Robot):
             serial_port=self.config.port,
             disable_torque_on_disconnect=self.config.disable_torque_on_disconnect,
             max_gripper_torque_nm=self.config.max_gripper_torque,
+            joint_velocity_scaling=self.config.joint_velocity_scaling,
         )
         self._rt_robot = DK1RobotRT(rt_config)
         self._rt_robot.connect()
         self.bus_connected = True
-        logger.info(f"{self} connected via C++ RT control loop")
+        logger.info(
+            f"{self} connected via C++ RT control loop "
+            f"(joint_velocity_scaling={self.config.joint_velocity_scaling})"
+        )
 
     @property
     def is_calibrated(self) -> bool:

--- a/lerobot_robot_trlc_dk1/follower.py
+++ b/lerobot_robot_trlc_dk1/follower.py
@@ -42,6 +42,8 @@ class DK1FollowerConfig(RobotConfig):
     joint_velocity_scaling: float = 0.2
     max_gripper_torque: float = 1.0 # Nm (/0.00875m spur gear radius = 114N gripper force)
     cameras: dict[str, CameraConfig] = field(default_factory=dict)
+    # Control mode: "pos_vel" (Python serial) or "rt_impedance" (C++ RT loop at 250Hz)
+    control_mode: str = "rt_impedance"
 
 
 class DK1Follower(Robot):
@@ -81,6 +83,7 @@ class DK1Follower(Robot):
         self.control = None
         self.serial_device = None
         self.bus_connected = False
+        self._rt_robot = None  # DK1RobotRT instance when using rt_impedance mode
 
         self.gripper_open_pos = 0.0
         self.gripper_closed_pos = -4.7
@@ -107,22 +110,41 @@ class DK1Follower(Robot):
 
     @property
     def is_connected(self) -> bool:
-        return self.bus_connected and all(cam.is_connected for cam in self.cameras.values())
+        bus_ok = self.bus_connected or (self._rt_robot is not None)
+        return bus_ok and all(cam.is_connected for cam in self.cameras.values())
 
     def connect(self) -> None:
         if self.is_connected:
             raise DeviceAlreadyConnectedError(f"{self} already connected")
 
-        self.serial_device = serial.Serial(
-            self.config.port, 921600, timeout=0.5)
-        time.sleep(0.5)
+        if self.config.control_mode == "rt_impedance":
+            self._connect_rt()
+        else:
+            self.serial_device = serial.Serial(
+                self.config.port, 921600, timeout=0.5)
+            time.sleep(0.5)
 
-        self.control = MotorControl(self.serial_device)
-        self.bus_connected = True
-        self.configure()
+            self.control = MotorControl(self.serial_device)
+            self.bus_connected = True
+            self.configure()
 
         for cam in self.cameras.values():
             cam.connect()
+
+    def _connect_rt(self) -> None:
+        """Connect using the C++ RT control loop."""
+        from trlc_dk1_control.config import DK1RobotConfig
+        from trlc_dk1_control.rt_robot import DK1RobotRT
+
+        rt_config = DK1RobotConfig(
+            serial_port=self.config.port,
+            disable_torque_on_disconnect=self.config.disable_torque_on_disconnect,
+            max_gripper_torque_nm=self.config.max_gripper_torque,
+        )
+        self._rt_robot = DK1RobotRT(rt_config)
+        self._rt_robot.connect()
+        self.bus_connected = True
+        logger.info(f"{self} connected via C++ RT control loop")
 
     @property
     def is_calibrated(self) -> bool:
@@ -141,7 +163,7 @@ class DK1Follower(Robot):
                 time.sleep(0.01)
 
             if self.control.read_motor_param(motor, DM_variable.CTRL_MODE) is not None:
-                print(f"{key} ({motor.MotorType.name}) is connected.")
+                logger.info(f"{key} ({motor.MotorType.name}) is connected.")
 
                 self.control.switchControlMode(motor, Control_Type.POS_VEL)
                 self.control.enable(motor)
@@ -181,26 +203,35 @@ class DK1Follower(Robot):
         if not self.is_connected:
             raise DeviceNotConnectedError(f"{self} is not connected.")
 
-        # Read arm position
         start = time.perf_counter()
-
         obs_dict = {}
-        for key, motor in self.motors.items():
-            self.control.refresh_motor_status(motor)
-            if key == "gripper":
-                # Normalize gripper position between 1 (closed) and 0 (open)
-                obs_dict[f"{key}.pos"] = map_range(
-                    motor.getPosition(), self.gripper_open_pos, self.gripper_closed_pos, 0.0, 1.0)
-            else:
-                obs_dict[f"{key}.pos"] = motor.getPosition()
+
+        if self._rt_robot is not None:
+            # RT mode: read via seqlock (~1 microsecond, thread-safe)
+            joint_state = self._rt_robot.get_joint_state()
+            gripper_state = self._rt_robot.get_gripper_state()
+            motor_names = ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
+            for i, name in enumerate(motor_names):
+                obs_dict[f"{name}.pos"] = float(joint_state["pos"][i])
+            obs_dict["gripper.pos"] = float(gripper_state["pos"])
+        else:
+            # Python serial mode
+            for key, motor in self.motors.items():
+                self.control.refresh_motor_status(motor)
+                if key == "gripper":
+                    obs_dict[f"{key}.pos"] = map_range(
+                        motor.getPosition(), self.gripper_open_pos, self.gripper_closed_pos, 0.0, 1.0)
+                else:
+                    obs_dict[f"{key}.pos"] = motor.getPosition()
 
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read state: {dt_ms:.1f}ms")
 
-        # Capture images from cameras
+        # Capture images from cameras — use read_latest() for non-blocking reads
+        # when the recording loop runs faster than camera FPS
         for cam_key, cam in self.cameras.items():
             start = time.perf_counter()
-            obs_dict[cam_key] = cam.async_read()
+            obs_dict[cam_key] = cam.read_latest()
             dt_ms = (time.perf_counter() - start) * 1e3
             logger.debug(f"{self} read {cam_key}: {dt_ms:.1f}ms")
 
@@ -213,19 +244,27 @@ class DK1Follower(Robot):
         goal_pos = {key.removesuffix(
             ".pos"): val for key, val in action.items() if key.endswith(".pos")}
 
-        # Send goal position to the arm
-        for key, motor in self.motors.items():
-            if key == "gripper":
-                self.control.refresh_motor_status(motor)
-                gripper_goal_pos_mapped = map_range(goal_pos[key], 0.0, 1.0, self.gripper_open_pos, self.gripper_closed_pos)
-                self.control.control_pos_force(motor, gripper_goal_pos_mapped, self.DM4310_SPEED*self.EMIT_VELOCITY_SCALE,
-                                               i_des=self.config.max_gripper_torque/self.DM4310_TORQUE_CONSTANT*self.EMIT_CURRENT_SCALE)
-            else:
-                if key in self.JOINT_LIMITS:
-                    goal_pos[key] = np.clip(goal_pos[key], self.JOINT_LIMITS[key][0], self.JOINT_LIMITS[key][1])
+        if self._rt_robot is not None:
+            # RT mode: write via seqlock (~1 microsecond, thread-safe)
+            motor_names = ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
+            q_des = np.array([goal_pos.get(name, 0.0) for name in motor_names], dtype=np.float64)
+            self._rt_robot.command_joint_pos(q_des)
+            if "gripper" in goal_pos:
+                self._rt_robot.command_gripper(float(goal_pos["gripper"]))
+        else:
+            # Python serial mode
+            for key, motor in self.motors.items():
+                if key == "gripper":
+                    self.control.refresh_motor_status(motor)
+                    gripper_goal_pos_mapped = map_range(goal_pos[key], 0.0, 1.0, self.gripper_open_pos, self.gripper_closed_pos)
+                    self.control.control_pos_force(motor, gripper_goal_pos_mapped, self.DM4310_SPEED*self.EMIT_VELOCITY_SCALE,
+                                                   i_des=self.config.max_gripper_torque/self.DM4310_TORQUE_CONSTANT*self.EMIT_CURRENT_SCALE)
+                else:
+                    if key in self.JOINT_LIMITS:
+                        goal_pos[key] = np.clip(goal_pos[key], self.JOINT_LIMITS[key][0], self.JOINT_LIMITS[key][1])
 
-                self.control.control_Pos_Vel(
-                    motor, goal_pos[key], self.config.joint_velocity_scaling*self.DM4340_SPEED)
+                    self.control.control_Pos_Vel(
+                        motor, goal_pos[key], self.config.joint_velocity_scaling*self.DM4340_SPEED)
 
         return {f"{motor}.pos": val for motor, val in goal_pos.items()}
 
@@ -233,11 +272,15 @@ class DK1Follower(Robot):
         if not self.is_connected:
             raise DeviceNotConnectedError(f"{self} is not connected.")
 
-        if self.config.disable_torque_on_disconnect:
-            for motor in self.motors.values():
-                self.control.disable(motor)
-        else:
-            self.control.serial_.close()
+        if self._rt_robot is not None:
+            self._rt_robot.disconnect()
+            self._rt_robot = None
+        elif self.control is not None:
+            if self.config.disable_torque_on_disconnect:
+                for motor in self.motors.values():
+                    self.control.disable(motor)
+            else:
+                self.control.serial_.close()
         self.bus_connected = False
 
         for cam in self.cameras.values():

--- a/lerobot_robot_trlc_dk1/follower.py
+++ b/lerobot_robot_trlc_dk1/follower.py
@@ -203,6 +203,33 @@ class DK1Follower(Robot):
         self.control.switchControlMode(
             self.motors["gripper"], Control_Type.Torque_Pos)
 
+    def get_joint_torques(self) -> dict[str, float]:
+        """Per-motor torque readings (Nm), straight from the RT loop.
+
+        NOT in ``observation_features`` on purpose: this is a side-channel
+        for runtime UX (haptic feedback), not for dataset recording — adding
+        torque keys to the schema would break policies trained without
+        them. Returns ``{}`` outside RT mode (the Python serial path
+        doesn't surface torque cheaply).
+
+        v1 returns only the gripper torque. Arm joint torques are also
+        available from ``_rt_robot.get_joint_state()["torque"]`` but are
+        gravity-comp dominated at rest, which makes them unsuitable for
+        "is something pushing on the arm" UX without subtracting the
+        gravity model.
+        """
+        if self._rt_robot is None:
+            return {}
+        gripper_state = self._rt_robot.get_gripper_state()
+        # `pos` (normalized 0..1, 0=open / 1=closed) is included alongside
+        # the torque so downstream consumers can compute a numerical
+        # velocity and subtract the inertia/kinetic-friction component
+        # from the haptic intensity. Cheap to ship; ignored if not used.
+        return {
+            "gripper.torque": float(gripper_state["torque"]),
+            "gripper.pos":    float(gripper_state["pos"]),
+        }
+
     def get_observation(self) -> dict[str, Any]:
         if not self.is_connected:
             raise DeviceNotConnectedError(f"{self} is not connected.")

--- a/lerobot_robot_trlc_dk1/follower.py
+++ b/lerobot_robot_trlc_dk1/follower.py
@@ -230,7 +230,19 @@ class DK1Follower(Robot):
             "gripper.pos":    float(gripper_state["pos"]),
         }
 
-    def get_observation(self) -> dict[str, Any]:
+    def get_observation(self, ref_ts_ns: int | None = None) -> dict[str, Any]:
+        """Return motor + (optional per-arm) camera observation.
+
+        When ``ref_ts_ns`` is given and the RT loop's state ring contains a
+        sample at-or-before it, the motor readings are sourced from that
+        sample (Option C: timestamp-aligned observation). The cameras are
+        likewise asked for their frame at-or-before ``ref_ts_ns`` when they
+        support ``read_at_or_before``. Any alignment failure falls back to
+        the legacy latest-of-everything behavior — never raises.
+
+        ``ref_ts_ns`` is a CLOCK_MONOTONIC nanosecond timestamp. Use ``None``
+        (the default) to get the previous "latest" semantics.
+        """
         if not self.is_connected:
             raise DeviceNotConnectedError(f"{self} is not connected.")
 
@@ -238,15 +250,28 @@ class DK1Follower(Robot):
         obs_dict = {}
 
         if self._rt_robot is not None:
-            # RT mode: read via seqlock (~1 microsecond, thread-safe)
-            joint_state = self._rt_robot.get_joint_state()
-            gripper_state = self._rt_robot.get_gripper_state()
             motor_names = ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
-            for i, name in enumerate(motor_names):
-                obs_dict[f"{name}.pos"] = float(joint_state["pos"][i])
-            obs_dict["gripper.pos"] = float(gripper_state["pos"])
+            aligned = None
+            if ref_ts_ns is not None:
+                aligned = self._rt_robot.get_state_at(ref_ts_ns)
+            if aligned is not None:
+                # Option C: aligned read from the ring.
+                joint_pos = aligned["joint_pos"]
+                gripper_pos = aligned["gripper_pos"]
+                # Normalize gripper_pos to [0, 1] like the latest API does. The
+                # C++ side already applied this for the snapshot, so use as-is.
+                for i, name in enumerate(motor_names):
+                    obs_dict[f"{name}.pos"] = float(joint_pos[i])
+                obs_dict["gripper.pos"] = float(gripper_pos)
+            else:
+                # Latest-via-seqlock (legacy / fallback when alignment isn't available).
+                joint_state = self._rt_robot.get_joint_state()
+                gripper_state = self._rt_robot.get_gripper_state()
+                for i, name in enumerate(motor_names):
+                    obs_dict[f"{name}.pos"] = float(joint_state["pos"][i])
+                obs_dict["gripper.pos"] = float(gripper_state["pos"])
         else:
-            # Python serial mode
+            # Python serial mode — no alignment possible
             for key, motor in self.motors.items():
                 self.control.refresh_motor_status(motor)
                 if key == "gripper":
@@ -258,11 +283,17 @@ class DK1Follower(Robot):
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read state: {dt_ms:.1f}ms")
 
-        # Capture images from cameras — use read_latest() for non-blocking reads
-        # when the recording loop runs faster than camera FPS
+        # Capture images from cameras — use read_at_or_before() when alignment
+        # is requested and the camera supports it; fall back to read_latest()
+        # otherwise (e.g. OpenCVCamera doesn't carry kernel timestamps).
         for cam_key, cam in self.cameras.items():
             start = time.perf_counter()
-            obs_dict[cam_key] = cam.read_latest()
+            frame = None
+            if ref_ts_ns is not None and hasattr(cam, "read_at_or_before"):
+                frame = cam.read_at_or_before(ref_ts_ns)
+            if frame is None:
+                frame = cam.read_latest()
+            obs_dict[cam_key] = frame
             dt_ms = (time.perf_counter() - start) * 1e3
             logger.debug(f"{self} read {cam_key}: {dt_ms:.1f}ms")
 

--- a/lerobot_robot_trlc_dk1/follower.py
+++ b/lerobot_robot_trlc_dk1/follower.py
@@ -235,7 +235,7 @@ class DK1Follower(Robot):
 
         When ``ref_ts_ns`` is given and the RT loop's state ring contains a
         sample at-or-before it, the motor readings are sourced from that
-        sample (Option C: timestamp-aligned observation). The cameras are
+        sample (timestamp-aligned observation). The cameras are
         likewise asked for their frame at-or-before ``ref_ts_ns`` when they
         support ``read_at_or_before``. Any alignment failure falls back to
         the legacy latest-of-everything behavior — never raises.
@@ -255,7 +255,7 @@ class DK1Follower(Robot):
             if ref_ts_ns is not None:
                 aligned = self._rt_robot.get_state_at(ref_ts_ns)
             if aligned is not None:
-                # Option C: aligned read from the ring.
+                # Aligned read: sample from the state ring at-or-before ref_ts_ns.
                 joint_pos = aligned["joint_pos"]
                 gripper_pos = aligned["gripper_pos"]
                 # Normalize gripper_pos to [0, 1] like the latest API does. The

--- a/lerobot_robot_trlc_dk1/leader.py
+++ b/lerobot_robot_trlc_dk1/leader.py
@@ -46,12 +46,12 @@ class DK1Leader(Teleoperator):
         self.bus = DynamixelMotorsBus(
             port=self.config.port,
             motors={
-                "joint_1": Motor(1, "xl330-m077", MotorNormMode.DEGREES),
-                "joint_2": Motor(2, "xl330-m077", MotorNormMode.DEGREES),
+                "joint_1": Motor(1, "xl330-m288", MotorNormMode.DEGREES),
+                "joint_2": Motor(2, "xl330-m288", MotorNormMode.DEGREES),
                 "joint_3": Motor(3, "xl330-m077", MotorNormMode.DEGREES),
                 "joint_4": Motor(4, "xl330-m077", MotorNormMode.DEGREES),
-                "joint_5": Motor(5, "xl330-m077", MotorNormMode.DEGREES),
-                "joint_6": Motor(6, "xl330-m077", MotorNormMode.DEGREES),
+                "joint_5": Motor(5, "xl330-m288", MotorNormMode.DEGREES),
+                "joint_6": Motor(6, "xl330-m288", MotorNormMode.DEGREES),
                 "gripper": Motor(7, "xl330-m077", MotorNormMode.DEGREES),
             },
         )
@@ -107,7 +107,7 @@ class DK1Leader(Teleoperator):
 
         start = time.perf_counter()
         
-        action = self.bus.sync_read(normalize=False, data_name="Present_Position")
+        action = self.bus.sync_read(normalize=False, data_name="Present_Position", num_retry=2)
         action = {f"{motor}.pos": (val/4096*2*np.pi-np.pi) if motor != "gripper" else val for motor, val in action.items()}
         
         # # Normalize gripper position between 1 (closed) and 0 (open)

--- a/lerobot_robot_trlc_dk1/leader.py
+++ b/lerobot_robot_trlc_dk1/leader.py
@@ -14,6 +14,7 @@
 
 from dataclasses import dataclass
 import logging
+import os
 import time
 import numpy as np
 
@@ -26,6 +27,31 @@ from lerobot.motors.dynamixel import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Hardware revision selector — "new" (default) matches the current shipping
+# leader (mixed xl330-m288/m077 → motor models 1200/1190). "old" matches the
+# earlier leader where every joint is xl330-m077 (all 1190). Set via the
+# LEADER_HW_REV env var; the Makefile exports it from `make.local`.
+_HW_REV_MOTORS = {
+    "new": {
+        "joint_1": ("xl330-m288", 1),
+        "joint_2": ("xl330-m288", 2),
+        "joint_3": ("xl330-m077", 3),
+        "joint_4": ("xl330-m077", 4),
+        "joint_5": ("xl330-m288", 5),
+        "joint_6": ("xl330-m288", 6),
+        "gripper": ("xl330-m077", 7),
+    },
+    "old": {
+        "joint_1": ("xl330-m077", 1),
+        "joint_2": ("xl330-m077", 2),
+        "joint_3": ("xl330-m077", 3),
+        "joint_4": ("xl330-m077", 4),
+        "joint_5": ("xl330-m077", 5),
+        "joint_6": ("xl330-m077", 6),
+        "gripper": ("xl330-m077", 7),
+    },
+}
 
 
 @TeleoperatorConfig.register_subclass("dk1_leader")
@@ -43,16 +69,16 @@ class DK1Leader(Teleoperator):
     def __init__(self, config: DK1LeaderConfig):
         super().__init__(config)
         self.config = config
+        hw_rev = os.environ.get("LEADER_HW_REV", "new").strip().lower()
+        if hw_rev not in _HW_REV_MOTORS:
+            raise ValueError(
+                f"LEADER_HW_REV must be one of {sorted(_HW_REV_MOTORS)}, got {hw_rev!r}"
+            )
         self.bus = DynamixelMotorsBus(
             port=self.config.port,
             motors={
-                "joint_1": Motor(1, "xl330-m288", MotorNormMode.DEGREES),
-                "joint_2": Motor(2, "xl330-m288", MotorNormMode.DEGREES),
-                "joint_3": Motor(3, "xl330-m077", MotorNormMode.DEGREES),
-                "joint_4": Motor(4, "xl330-m077", MotorNormMode.DEGREES),
-                "joint_5": Motor(5, "xl330-m288", MotorNormMode.DEGREES),
-                "joint_6": Motor(6, "xl330-m288", MotorNormMode.DEGREES),
-                "gripper": Motor(7, "xl330-m077", MotorNormMode.DEGREES),
+                name: Motor(motor_id, model, MotorNormMode.DEGREES)
+                for name, (model, motor_id) in _HW_REV_MOTORS[hw_rev].items()
             },
         )
 

--- a/lerobot_robot_trlc_dk1/motors/DM_Control_Python/DM_CAN.py
+++ b/lerobot_robot_trlc_dk1/motors/DM_Control_Python/DM_CAN.py
@@ -1,8 +1,11 @@
+import logging
 from time import sleep
 import numpy as np
 from enum import IntEnum
 from struct import unpack
 from struct import pack
+
+_dm_logger = logging.getLogger(__name__)
 
 
 class Motor:
@@ -83,7 +86,7 @@ class MotorControl:
         self.motors_map = dict()
         self.data_save = bytes()  # save data
         if self.serial_.is_open:  # open the serial port
-            print("Serial port is open")
+            _dm_logger.debug("Serial port is open")
             serial_device.close()
         self.serial_.open()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["scikit-build-core>=0.10", "nanobind>=2.4", "mujoco>=3.0.0"]
+build-backend = "scikit_build_core.build"
 
 [project]
 name = "lerobot_robot_trlc_dk1"
@@ -10,7 +10,7 @@ dependencies = [
   "numpy>=2.0.1",
   "pyserial>=3.5",
   "dynamixel-sdk>=3.7.31",
-  "lerobot@https://github.com/huggingface/lerobot.git",
+  "mujoco>=3.0.0",
 ]
 
 authors = [
@@ -20,9 +20,13 @@ maintainers = [
   {name = "Jannik Grothusen", email = "jannik@robot-learning.co"},
 ]
 
+[project.optional-dependencies]
+rt = []  # C++ extension is built by scikit-build-core when installed
+
 [project.urls]
 Homepage = "https://www.robot-learning.co/"
 Documentation = "https://www.docs.robot-learning.co/"
 
-[tool.hatch.metadata]
-allow-direct-references = true
+[tool.scikit-build]
+cmake.source-dir = "csrc"
+cmake.build-type = "Release"

--- a/trlc_dk1_control/__init__.py
+++ b/trlc_dk1_control/__init__.py
@@ -1,0 +1,4 @@
+from .config import DK1RobotConfig, DK1_DEFAULT_CONFIG
+from .robot import DK1Robot
+
+__all__ = ["DK1Robot", "DK1RobotConfig", "DK1_DEFAULT_CONFIG"]

--- a/trlc_dk1_control/config.py
+++ b/trlc_dk1_control/config.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+_REPO_ROOT = Path(__file__).parent.parent
+_DEFAULT_URDF = str(_REPO_ROOT / "urdf" / "follower" / "TRLC-DK1-Follower.urdf")
+
+
+DM4310_IDX = 0   # Limit_Param[0] = [12.5, 30, 10]
+DM4340_IDX = 2   # Limit_Param[2] = [12.5, 8, 28]
+
+DM4310_Q_MAX = 12.5    # rad
+DM4310_DQ_MAX = 30.0   # rad/s
+DM4310_T_MAX = 10.0    # Nm
+
+DM4340_Q_MAX = 12.5    # rad
+DM4340_DQ_MAX = 8.0    # rad/s  (52.5 rpm)
+DM4340_T_MAX = 28.0    # Nm
+
+# MIT gain ranges (from DM_CAN.py float_to_uint constraints)
+KP_MAX = 500.0
+KD_MAX = 5.0
+
+
+@dataclass
+class DK1RobotConfig:
+    """All tunable parameters for the TRLC-DK1 control stack."""
+
+    # Serial communication
+    serial_port: str = "/dev/ttyACM0"
+    serial_timeout: float = 0.005   # 5 ms — must be short for 250 Hz loop
+
+    # Thread rates
+    motor_thread_hz: float = 250.0
+    server_thread_hz: float = 300.0
+
+    # MIT PD gains for 6 arm joints [j1, j2, j3, j4, j5, j6]
+    arm_kp: np.ndarray = field(
+        default_factory=lambda: np.array([80.0, 70.0, 60.0, 20.0, 20.0, 10.0])
+    )
+    arm_kd: np.ndarray = field(
+        default_factory=lambda: np.array([5.0, 5.0, 4.0, 1.0, 1.0, 1.0])
+    )
+
+    # Joint position limits (radians), shape (6, 2) — [min, max] per joint
+    # Joints 1-3 (DM4340): physically limited by arm geometry; use conservative ±π
+    # Joints 4-5 (DM4310): taken from follower.py JOINT_LIMITS
+    # Joint 6   (DM4310): full ±π
+    joint_pos_limits: np.ndarray = field(
+        default_factory=lambda: np.array([
+            [-math.pi,       math.pi      ],   # joint_1
+            [-math.pi,       math.pi      ],   # joint_2
+            [-math.pi,       math.pi      ],   # joint_3
+            [-100*math.pi/180, 100*math.pi/180],  # joint_4
+            [-90*math.pi/180,  90*math.pi/180 ],  # joint_5
+            [-math.pi,       math.pi      ],   # joint_6
+        ])
+    )
+
+    # Joint torque limits (Nm) per joint — matches motor T_MAX
+    joint_torque_limits: np.ndarray = field(
+        default_factory=lambda: np.array([28.0, 28.0, 28.0, 10.0, 10.0, 10.0])
+    )
+
+    # URDF path (used for kinematics / visualisation)
+    urdf_path: str = _DEFAULT_URDF
+
+    # Gravity compensation
+    mjcf_path: str = _DEFAULT_URDF   # path to MuJoCo XML; empty = gravity comp disabled
+    gravity_comp_scale: float = 1.0  # tune empirically
+
+    # Joint velocity limits (rad/s) per joint — operational safety limit
+    joint_velocity_limits: np.ndarray = field(
+        default_factory=lambda: np.array([5.0, 5.0, 5.0, 15.0, 15.0, 15.0])
+    )
+
+    # Slew rate limit: max position change per cycle (rad/cycle) per joint
+    # At 250 Hz: 0.02 rad/cycle = 5 rad/s, 0.06 rad/cycle = 15 rad/s. 0.0 disables.
+    max_pos_delta_per_cycle: np.ndarray = field(
+        default_factory=lambda: np.array([0.02, 0.02, 0.02, 0.06, 0.06, 0.06])
+    )
+
+    # Safety watchdog
+    command_timeout_s: float = 0.5    # hold position (damping only) after this idle period
+    overcurrent_threshold: int = 20   # consecutive over-limit torque counts before damping
+    overspeed_threshold: int = 5      # consecutive over-limit velocity counts before damping
+    min_motors_required: int = 6      # throw if fewer arm motors respond during init
+    gripper_cal_timeout_s: float = 10.0  # wall-clock timeout for gripper calibration
+
+    # Communication loss detection
+    max_consecutive_empty_cycles: int = 50  # cycles with 0 bytes before comm loss (200ms at 250Hz)
+
+    # Shutdown
+    disable_torque_on_disconnect: bool = True
+
+    # Gripper parameters
+    gripper_open_pos: float = 0.0     # rad offset from hard stop after calibration
+    gripper_closed_pos: float = -4.7  # rad
+    max_gripper_torque_nm: float = 1.0
+    DM4310_TORQUE_CONSTANT: float = 0.945  # Nm/A
+    EMIT_VELOCITY_SCALE: float = 100.0     # rad/s multiplier for EMIT mode
+    EMIT_CURRENT_SCALE: float = 1000.0     # A multiplier for EMIT mode
+
+
+def DK1_DEFAULT_CONFIG(serial_port: str, mjcf_path: str = _DEFAULT_URDF) -> DK1RobotConfig:
+    """Return a default DK1RobotConfig for the standard 6-DOF arm + gripper."""
+    return DK1RobotConfig(
+        serial_port=serial_port,
+        mjcf_path=mjcf_path,
+    )

--- a/trlc_dk1_control/config.py
+++ b/trlc_dk1_control/config.py
@@ -84,6 +84,12 @@ class DK1RobotConfig:
         default_factory=lambda: np.array([0.02, 0.02, 0.02, 0.06, 0.06, 0.06])
     )
 
+    # Multiplier applied to joint_velocity_limits and max_pos_delta_per_cycle when the
+    # config is fed into the C++ RT loop. Lets the operator dial down speed at runtime
+    # (e.g. for first-run policy eval) without editing the per-joint defaults above.
+    # Range (0, 1]. Values outside this range are clamped at the call site.
+    joint_velocity_scaling: float = 1.0
+
     # Safety watchdog
     command_timeout_s: float = 0.5    # hold position (damping only) after this idle period
     overcurrent_threshold: int = 20   # consecutive over-limit torque counts before damping

--- a/trlc_dk1_control/gravity_comp.py
+++ b/trlc_dk1_control/gravity_comp.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class GravityCompensator:
+    """
+    Computes gravity compensation torques using MuJoCo inverse dynamics.
+
+    Only the first `num_dofs` joints of the model are used (arm joints).
+    The gripper is excluded — its gravity contribution is negligible and
+    it operates in force-position (EMIT) mode.
+
+    The URDF must contain ``<mujoco><compiler strippath="false"/></mujoco>``
+    so that MuJoCo can resolve relative mesh paths.
+
+    Args:
+        model_path: Path to a MuJoCo XML (.xml) or URDF (.urdf) file.
+        num_dofs:   Number of arm joints to compute torques for (default 6).
+    """
+
+    def __init__(self, model_path: str, num_dofs: int = 6) -> None:
+        try:
+            import mujoco
+        except ImportError as e:
+            raise ImportError(
+                "mujoco is required for gravity compensation. "
+                "Install it with: pip install mujoco"
+            ) from e
+
+        self._mujoco = mujoco
+        self.num_dofs = num_dofs
+
+        self.mj_model = mujoco.MjModel.from_xml_path(model_path)
+        self.mj_data = mujoco.MjData(self.mj_model)
+
+        if self.mj_model.nq < num_dofs:
+            raise ValueError(
+                f"MuJoCo model has {self.mj_model.nq} DoFs but num_dofs={num_dofs}"
+            )
+
+        logger.info(
+            "GravityCompensator loaded: %s (%d DoF model, using first %d)",
+            model_path,
+            self.mj_model.nq,
+            num_dofs,
+        )
+
+    def compute(self, q: np.ndarray) -> np.ndarray:
+        """
+        Compute gravity compensation torques for the arm joints.
+
+        Args:
+            q: Joint positions (radians), shape (num_dofs,) or larger.
+
+        Returns:
+            tau_grav: Gravity torques, shape (num_dofs,).
+        """
+        mujoco = self._mujoco
+        self.mj_data.qpos[: self.num_dofs] = q[: self.num_dofs]
+        self.mj_data.qvel[:] = 0.0
+        self.mj_data.qacc[:] = 0.0
+        # Use mj_forward + qfrc_bias instead of mj_inverse + qfrc_inverse.
+        # mj_inverse includes constraint forces from joint limits which can
+        # produce wildly incorrect torques near limit boundaries.
+        # qfrc_bias with qvel=0 gives pure gravity torques.
+        mujoco.mj_forward(self.mj_model, self.mj_data)
+        return self.mj_data.qfrc_bias[: self.num_dofs].copy()
+
+
+class NoGravityComp:
+    """Drop-in replacement when gravity compensation is disabled."""
+
+    num_dofs: int = 6
+
+    def compute(self, q: np.ndarray) -> np.ndarray:
+        return np.zeros(self.num_dofs)

--- a/trlc_dk1_control/motor_chain.py
+++ b/trlc_dk1_control/motor_chain.py
@@ -1,0 +1,329 @@
+"""
+DK1MotorChain — 250 Hz background thread for motor control.
+
+Architecture:
+  - One background thread (motor_thread_hz) handles all serial I/O.
+  - The thread sends MIT commands to arm joints and EMIT commands to the gripper,
+    then reads back motor state.  State and commands are shared with the server thread
+    via a single threading.Lock.
+  - Serial timeout is set to 5 ms (not 500 ms) so recv() never blocks the control loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+
+import numpy as np
+import serial
+
+# Add the DM_Control_Python directory to path so we can import DM_CAN
+import os
+_DM_CAN_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..", "lerobot_robot_trlc_dk1", "motors", "DM_Control_Python"
+)
+sys.path.insert(0, os.path.abspath(_DM_CAN_DIR))
+
+from DM_CAN import (  # noqa: E402
+    Motor,
+    MotorControl,
+    DM_Motor_Type,
+    Control_Type,
+    DM_variable,
+)
+
+from .config import DK1RobotConfig, DM4310_DQ_MAX
+
+logger = logging.getLogger(__name__)
+
+# Number of arm joints (excludes gripper)
+NUM_ARM_JOINTS = 6
+
+
+class DK1MotorChain:
+    """
+    Wraps DM_CAN.MotorControl and runs a 250 Hz background thread.
+
+    Thread-safety: all shared state is protected by `_lock`.
+    """
+
+    def __init__(self, config: DK1RobotConfig) -> None:
+        self._config = config
+        self._lock = threading.Lock()
+
+        # Shared state (written by motor thread, read by server thread)
+        self._pos = np.zeros(7)     # radians, [joint_1..joint_6, gripper]
+        self._vel = np.zeros(7)     # rad/s
+        self._torque = np.zeros(7)  # Nm
+
+        # Shared commands (written by server thread, read by motor thread)
+        self._arm_kp = config.arm_kp.copy()
+        self._arm_kd = config.arm_kd.copy()
+        self._arm_q_des = np.zeros(NUM_ARM_JOINTS)
+        self._arm_dq_des = np.zeros(NUM_ARM_JOINTS)
+        self._arm_tau_ff = np.zeros(NUM_ARM_JOINTS)
+
+        self._gripper_q_des = config.gripper_open_pos
+        self._gripper_vel = DM4310_DQ_MAX * config.EMIT_VELOCITY_SCALE
+        self._gripper_i_des = (
+            config.max_gripper_torque_nm
+            / config.DM4310_TORQUE_CONSTANT
+            * config.EMIT_CURRENT_SCALE
+        )
+
+        # Set by motor thread to indicate actual gripper zero after calibration
+        self.gripper_open_pos: float = config.gripper_open_pos
+
+        # Motor objects — created in start()
+        self._motors: dict[str, Motor] = {}
+        self._control: MotorControl | None = None
+        self._serial_device: serial.Serial | None = None
+
+        self._running = False
+        self._thread: threading.Thread | None = None
+
+        # Performance tracking
+        self._loop_count = 0
+        self._last_perf_log = time.monotonic()
+
+    # -------------------------------------------------------------------------
+    # Public API (thread-safe)
+    # -------------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Open serial port, configure motors, start background thread."""
+        if self._running:
+            raise RuntimeError("DK1MotorChain already running")
+
+        self._serial_device = serial.Serial(
+            self._config.serial_port,
+            921600,
+            timeout=self._config.serial_timeout,
+        )
+        time.sleep(0.5)
+
+        self._control = MotorControl(self._serial_device)
+        self._configure()
+
+        # Initialise desired position to current position so we don't jump on start
+        with self._lock:
+            self._arm_q_des = self._pos[:NUM_ARM_JOINTS].copy()
+
+        self._running = True
+        self._thread = threading.Thread(target=self._motor_loop, daemon=True, name="dk1-motor")
+        self._thread.start()
+        logger.info("DK1MotorChain started at %.0f Hz", self._config.motor_thread_hz)
+
+    def stop(self) -> None:
+        """Stop the background thread and disable all motors."""
+        if not self._running:
+            return
+        self._running = False
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        if self._control is not None:
+            for motor in self._motors.values():
+                try:
+                    self._control.disable(motor)
+                except Exception:
+                    pass
+        if self._serial_device is not None:
+            self._serial_device.close()
+        logger.info("DK1MotorChain stopped")
+
+    def set_arm_commands(
+        self,
+        kp: np.ndarray,
+        kd: np.ndarray,
+        q_des: np.ndarray,
+        dq_des: np.ndarray,
+        tau_ff: np.ndarray,
+    ) -> None:
+        """Update MIT command buffer for arm joints 1-6 (non-blocking)."""
+        with self._lock:
+            self._arm_kp = kp
+            self._arm_kd = kd
+            self._arm_q_des = q_des
+            self._arm_dq_des = dq_des
+            self._arm_tau_ff = tau_ff
+
+    def set_gripper_command(self, q_des: float, vel: float, i_des: float) -> None:
+        """Update EMIT command for gripper (non-blocking)."""
+        with self._lock:
+            self._gripper_q_des = q_des
+            self._gripper_vel = vel
+            self._gripper_i_des = i_des
+
+    def get_state(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Return (pos(7,), vel(7,), torque(7,)) — thread-safe copy."""
+        with self._lock:
+            return self._pos.copy(), self._vel.copy(), self._torque.copy()
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    # -------------------------------------------------------------------------
+    # Setup
+    # -------------------------------------------------------------------------
+
+    def _configure(self) -> None:
+        """Mirror follower.py configure(), but use MIT mode for arm joints."""
+        assert self._control is not None
+
+        arm_joint_names = [f"joint_{i}" for i in range(1, 7)]
+        self._motors = {
+            "joint_1": Motor(DM_Motor_Type.DM4340, 0x01, 0x11),
+            "joint_2": Motor(DM_Motor_Type.DM4340, 0x02, 0x12),
+            "joint_3": Motor(DM_Motor_Type.DM4340, 0x03, 0x13),
+            "joint_4": Motor(DM_Motor_Type.DM4310, 0x04, 0x14),
+            "joint_5": Motor(DM_Motor_Type.DM4310, 0x05, 0x15),
+            "joint_6": Motor(DM_Motor_Type.DM4310, 0x06, 0x16),
+            "gripper": Motor(DM_Motor_Type.DM4310, 0x07, 0x17),
+        }
+
+        for key, motor in self._motors.items():
+            self._control.addMotor(motor)
+            for _ in range(3):
+                self._control.refresh_motor_status(motor)
+                time.sleep(0.01)
+            if self._control.read_motor_param(motor, DM_variable.CTRL_MODE) is None:
+                raise RuntimeError(f"Cannot communicate with motor {key!r}")
+            print(f"{key} ({motor.MotorType.name}) connected")
+
+        # Switch arm joints to MIT mode
+        for name in arm_joint_names:
+            motor = self._motors[name]
+            self._control.switchControlMode(motor, Control_Type.MIT)
+            self._control.enable(motor)
+
+        # Read initial arm state
+        for i, name in enumerate(arm_joint_names):
+            motor = self._motors[name]
+            self._control.refresh_motor_status(motor)
+            self._pos[i] = motor.getPosition()
+            self._vel[i] = motor.getVelocity()
+            self._torque[i] = motor.getTorque()
+
+        # Calibrate gripper: open until torque threshold, set as zero
+        self._calibrate_gripper()
+
+    def _calibrate_gripper(self) -> None:
+        """Spin gripper open until torque spike, then set zero position."""
+        assert self._control is not None
+        gripper = self._motors["gripper"]
+
+        self._control.switchControlMode(gripper, Control_Type.VEL)
+        self._control.enable(gripper)
+        self._control.control_Vel(gripper, 5.0)  # gentle homing speed
+
+        while True:
+            self._control.refresh_motor_status(gripper)
+            if gripper.getTorque() > 0.7:
+                self._control.control_Vel(gripper, 0.0)
+                self._control.disable(gripper)
+                self._control.set_zero_position(gripper)
+                time.sleep(0.2)
+                self._control.enable(gripper)
+                break
+            time.sleep(0.01)
+
+        # Back off slightly from the hard stop so the open position is force-free.
+        # After set_zero the encoder is 0 at the stop; open_pos is a small offset
+        # in the close direction (negative).
+        self.gripper_open_pos = self._config.gripper_open_pos
+
+        # Switch to EMIT (Torque_Pos) mode for force-controlled grasping
+        self._control.switchControlMode(gripper, Control_Type.Torque_Pos)
+
+        # Read initial gripper state
+        self._control.refresh_motor_status(gripper)
+        self._pos[6] = gripper.getPosition()
+        self._vel[6] = gripper.getVelocity()
+        self._torque[6] = gripper.getTorque()
+
+        print("Gripper calibrated: open position =", self.gripper_open_pos)
+
+    # -------------------------------------------------------------------------
+    # 250 Hz motor loop
+    # -------------------------------------------------------------------------
+
+    def _motor_loop(self) -> None:
+        assert self._control is not None
+        period = 1.0 / self._config.motor_thread_hz
+        arm_names = [f"joint_{i}" for i in range(1, 7)]
+
+        while self._running:
+            t_start = time.monotonic()
+
+            # Snapshot commands under lock
+            with self._lock:
+                kp = self._arm_kp.copy()
+                kd = self._arm_kd.copy()
+                q_des = self._arm_q_des.copy()
+                dq_des = self._arm_dq_des.copy()
+                tau_ff = self._arm_tau_ff.copy()
+                g_q_des = self._gripper_q_des
+                g_vel = self._gripper_vel
+                g_i_des = self._gripper_i_des
+
+            # Send MIT commands to arm joints and read feedback
+            for i, name in enumerate(arm_names):
+                motor = self._motors[name]
+                self._control.controlMIT(
+                    motor,
+                    float(kp[i]),
+                    float(kd[i]),
+                    float(q_des[i]),
+                    float(dq_des[i]),
+                    float(tau_ff[i]),
+                )
+
+            # Send EMIT command to gripper
+            self._control.control_pos_force(
+                self._motors["gripper"],
+                float(g_q_des),
+                float(g_vel),
+                float(g_i_des),
+            )
+
+            # Collect motor state (updated by recv() inside each control call)
+            new_pos = np.empty(7)
+            new_vel = np.empty(7)
+            new_torque = np.empty(7)
+            for i, name in enumerate(arm_names):
+                m = self._motors[name]
+                new_pos[i] = m.getPosition()
+                new_vel[i] = m.getVelocity()
+                new_torque[i] = m.getTorque()
+            gm = self._motors["gripper"]
+            new_pos[6] = gm.getPosition()
+            new_vel[6] = gm.getVelocity()
+            new_torque[6] = gm.getTorque()
+
+            # Update shared state buffer
+            with self._lock:
+                self._pos = new_pos
+                self._vel = new_vel
+                self._torque = new_torque
+
+            # Maintain loop period — sleep most of the time, busywait the tail
+            # for precision (time.sleep has ~1-2 ms granularity on macOS)
+            elapsed = time.monotonic() - t_start
+            sleep_time = period - elapsed
+            if sleep_time > 0.001:
+                time.sleep(sleep_time - 0.001)
+            while time.monotonic() - t_start < period:
+                pass
+
+            # Periodic performance print
+            self._loop_count += 1
+            now = time.monotonic()
+            if now - self._last_perf_log >= 5.0:
+                hz = self._loop_count / (now - self._last_perf_log)
+                print(f"[motor]  {hz:6.1f} Hz  (target {self._config.motor_thread_hz:.0f} Hz)  loop={elapsed*1e3:.2f} ms")
+                self._loop_count = 0
+                self._last_perf_log = now

--- a/trlc_dk1_control/robot.py
+++ b/trlc_dk1_control/robot.py
@@ -1,0 +1,280 @@
+"""
+DK1Robot — high-level control interface for the TRLC-DK1 arm.
+
+Architecture:
+
+    User code (any Hz)
+        command_joint_pos(q_des)   →  updates shared command buffer
+        get_joint_state()          →  reads from shared state buffer
+
+    Server thread (~300 Hz):
+        1. Read pos/vel/torque from motor chain
+        2. Watchdog: hold current position if no command received recently
+        3. Compute gravity compensation torque (MuJoCo)
+        4. Enforce safety: clip position, clip torque, over-current counter
+        5. Push updated MIT commands to motor chain
+
+    Motor thread (250 Hz) — lives inside DK1MotorChain:
+        controlMIT for arm joints + EMIT for gripper
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+import numpy as np
+
+from .config import DK1RobotConfig, DK1_DEFAULT_CONFIG, DM4310_DQ_MAX
+from .gravity_comp import GravityCompensator, NoGravityComp
+from .motor_chain import DK1MotorChain
+
+logger = logging.getLogger(__name__)
+
+# Position limit buffer: don't command within this margin of the hard limit (rad)
+LIMIT_BUFFER = 0.05
+
+
+class DK1Robot:
+    """
+    Standalone control stack for the TRLC-DK1 6-DOF arm + gripper.
+
+    Example::
+
+        cfg = DK1_DEFAULT_CONFIG("/dev/ttyUSB0", mjcf_path="robot.xml")
+        robot = DK1Robot(cfg)
+        robot.connect()
+
+        q = robot.get_joint_state()["pos"]
+        robot.command_joint_pos(q)  # hold current position
+        robot.command_gripper(0.0)  # open gripper
+
+        robot.disconnect()
+    """
+
+    def __init__(self, config: DK1RobotConfig) -> None:
+        self._config = config
+        self._motor_chain = DK1MotorChain(config)
+
+        if config.mjcf_path:
+            self._grav_comp: GravityCompensator | NoGravityComp = GravityCompensator(
+                config.mjcf_path
+            )
+        else:
+            self._grav_comp = NoGravityComp()
+            logger.warning("Gravity compensation disabled (no mjcf_path provided)")
+
+        # Server thread shared state — protected by _cmd_lock
+        self._cmd_lock = threading.Lock()
+        self._q_des = np.zeros(6)      # (6,) arm joint targets in radians
+        self._gripper_des = 0.0        # normalised gripper position [0=open, 1=closed]
+        self._last_cmd_time: float = 0.0
+        self._damping_mode: bool = False   # set when over-current threshold exceeded
+
+        # Safety counters
+        self._overcurrent_count: int = 0
+
+        self._server_running = False
+        self._server_thread: threading.Thread | None = None
+
+    # -------------------------------------------------------------------------
+    # Lifecycle
+    # -------------------------------------------------------------------------
+
+    def connect(self) -> None:
+        """Start motor chain and server thread. Blocks until motors are ready."""
+        self._motor_chain.start()
+
+        # Initialise desired position to current measured position (no startup jump)
+        pos, _, _ = self._motor_chain.get_state()
+        with self._cmd_lock:
+            self._q_des = pos[:6].copy()
+            self._last_cmd_time = time.monotonic()
+
+        self._server_running = True
+        self._server_thread = threading.Thread(
+            target=self._server_loop, daemon=True, name="dk1-server"
+        )
+        self._server_thread.start()
+        logger.info("DK1Robot connected")
+
+    def disconnect(self) -> None:
+        """Stop server thread and motor chain."""
+        self._server_running = False
+        if self._server_thread is not None:
+            self._server_thread.join(timeout=2.0)
+        self._motor_chain.stop()
+        logger.info("DK1Robot disconnected")
+
+    # -------------------------------------------------------------------------
+    # Command interface (thread-safe, non-blocking)
+    # -------------------------------------------------------------------------
+
+    def command_joint_pos(self, q_des: np.ndarray) -> None:
+        """
+        Set target joint positions for the 6 arm joints.
+
+        Args:
+            q_des: Target positions in radians, shape (6,).
+        """
+        if q_des.shape != (6,):
+            raise ValueError(f"Expected shape (6,), got {q_des.shape}")
+        with self._cmd_lock:
+            self._q_des = q_des.copy()
+            self._last_cmd_time = time.monotonic()
+            self._damping_mode = False  # reset on new command
+
+    def command_gripper(self, normalized_pos: float) -> None:
+        """
+        Set gripper target position.
+
+        Args:
+            normalized_pos: 0.0 = fully open, 1.0 = fully closed.
+        """
+        normalized_pos = float(np.clip(normalized_pos, 0.0, 1.0))
+        with self._cmd_lock:
+            self._gripper_des = normalized_pos
+
+    # -------------------------------------------------------------------------
+    # State interface (thread-safe)
+    # -------------------------------------------------------------------------
+
+    def get_joint_state(self) -> dict[str, np.ndarray]:
+        """
+        Return current arm joint state (excludes gripper).
+
+        Returns:
+            dict with keys 'pos', 'vel', 'torque', each shape (6,).
+        """
+        pos, vel, torque = self._motor_chain.get_state()
+        return {
+            "pos": pos[:6].copy(),
+            "vel": vel[:6].copy(),
+            "torque": torque[:6].copy(),
+        }
+
+    def get_gripper_state(self) -> dict[str, float]:
+        """Return normalised gripper position and torque."""
+        pos, _, torque = self._motor_chain.get_state()
+        cfg = self._config
+        normalized = np.interp(
+            pos[6],
+            [cfg.gripper_open_pos, cfg.gripper_closed_pos],
+            [0.0, 1.0],
+        )
+        return {"pos": float(np.clip(normalized, 0.0, 1.0)), "torque": float(torque[6])}
+
+    # -------------------------------------------------------------------------
+    # Server loop (~300 Hz)
+    # -------------------------------------------------------------------------
+
+    def _server_loop(self) -> None:
+        cfg = self._config
+        period = 1.0 / cfg.server_thread_hz
+        loop_count = 0
+        last_log = time.monotonic()
+
+        while self._server_running:
+            t_start = time.monotonic()
+
+            pos, vel, torque = self._motor_chain.get_state()
+
+            with self._cmd_lock:
+                q_des = self._q_des.copy()
+                gripper_des = self._gripper_des
+                last_cmd = self._last_cmd_time
+                damping = self._damping_mode
+
+            # ------------------------------------------------------------------
+            # Watchdog: if no command for timeout seconds, hold current position
+            # ------------------------------------------------------------------
+            now = time.monotonic()
+            if now - last_cmd > cfg.command_timeout_s:
+                q_des = pos[:6].copy()
+                with self._cmd_lock:
+                    self._q_des = q_des
+
+            # ------------------------------------------------------------------
+            # Gravity compensation
+            # ------------------------------------------------------------------
+            tau_ff = self._grav_comp.compute(pos[:6]) * cfg.gravity_comp_scale
+
+            # ------------------------------------------------------------------
+            # Safety: joint position clamping (with buffer)
+            # ------------------------------------------------------------------
+            lims = cfg.joint_pos_limits
+            q_des_safe = np.clip(
+                q_des,
+                lims[:, 0] + LIMIT_BUFFER,
+                lims[:, 1] - LIMIT_BUFFER,
+            )
+
+            # ------------------------------------------------------------------
+            # Safety: torque limit clipping
+            # ------------------------------------------------------------------
+            tau_ff_safe = np.clip(tau_ff, -cfg.joint_torque_limits, cfg.joint_torque_limits)
+
+            # ------------------------------------------------------------------
+            # Over-current detection
+            # ------------------------------------------------------------------
+            over_limit = np.abs(torque[:6]) > cfg.joint_torque_limits
+            if np.any(over_limit):
+                self._overcurrent_count += 1
+                if self._overcurrent_count >= cfg.overcurrent_threshold:
+                    logger.warning(
+                        "Over-current threshold reached (joints %s). Entering damping mode.",
+                        np.where(over_limit)[0] + 1,
+                    )
+                    damping = True
+                    with self._cmd_lock:
+                        self._damping_mode = True
+            else:
+                self._overcurrent_count = max(0, self._overcurrent_count - 1)
+
+            # In damping mode: zero stiffness, zero feedforward — only kd damping
+            if damping:
+                kp = np.zeros(6)
+                tau_ff_safe = np.zeros(6)
+                # Hold current position as target to prevent drift when exiting damping
+                q_des_safe = pos[:6].copy()
+            else:
+                kp = cfg.arm_kp
+
+            kd = cfg.arm_kd
+            dq_des = np.zeros(6)
+
+            # ------------------------------------------------------------------
+            # Push to motor chain
+            # ------------------------------------------------------------------
+            self._motor_chain.set_arm_commands(kp, kd, q_des_safe, dq_des, tau_ff_safe)
+
+            # Gripper command
+            gripper_q = float(np.interp(
+                gripper_des,
+                [0.0, 1.0],
+                [cfg.gripper_open_pos, cfg.gripper_closed_pos],
+            ))
+            gripper_vel = DM4310_DQ_MAX * cfg.EMIT_VELOCITY_SCALE
+            gripper_i_des = (
+                cfg.max_gripper_torque_nm
+                / cfg.DM4310_TORQUE_CONSTANT
+                * cfg.EMIT_CURRENT_SCALE
+            )
+            self._motor_chain.set_gripper_command(gripper_q, gripper_vel, gripper_i_des)
+
+            # ------------------------------------------------------------------
+            # Maintain period + periodic logging
+            # ------------------------------------------------------------------
+            elapsed = time.monotonic() - t_start
+            sleep_time = period - elapsed
+            if sleep_time > 0:
+                time.sleep(sleep_time)
+
+            loop_count += 1
+            now = time.monotonic()
+            if now - last_log >= 5.0:
+                hz = loop_count / (now - last_log)
+                print(f"[server] {hz:6.1f} Hz  (target {cfg.server_thread_hz:.0f} Hz)  loop={elapsed*1e3:.2f} ms")
+                loop_count = 0
+                last_log = now

--- a/trlc_dk1_control/rt_robot.py
+++ b/trlc_dk1_control/rt_robot.py
@@ -1,0 +1,171 @@
+"""
+DK1RobotRT — Drop-in replacement for DK1Robot using the C++ RT control loop.
+
+Uses the _trlc_dk1_rt nanobind extension for a single-threaded 250 Hz
+control loop with optional PREEMPT_RT support and lock-free communication.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from .config import DK1RobotConfig
+
+logger = logging.getLogger(__name__)
+
+# Default motor configuration matching motor_chain.py
+_DEFAULT_MOTORS = [
+    {"name": "joint_1", "type": "DM4340",  "slave_id": 0x01, "master_id": 0x11},
+    {"name": "joint_2", "type": "DM4340",  "slave_id": 0x02, "master_id": 0x12},
+    {"name": "joint_3", "type": "DM4340",  "slave_id": 0x03, "master_id": 0x13},
+    {"name": "joint_4", "type": "DM4310",  "slave_id": 0x04, "master_id": 0x14},
+    {"name": "joint_5", "type": "DM4310",  "slave_id": 0x05, "master_id": 0x15},
+    {"name": "joint_6", "type": "DM4310",  "slave_id": 0x06, "master_id": 0x16},
+    {"name": "gripper",  "type": "DM4310",  "slave_id": 0x07, "master_id": 0x17},
+]
+
+
+class DK1RobotRT:
+    """
+    Drop-in replacement for DK1Robot using the C++ RT control loop.
+
+    Provides the same public API as DK1Robot for use with DK1Follower
+    and other orchestration code.
+    """
+
+    def __init__(self, config: DK1RobotConfig) -> None:
+        try:
+            from trlc_dk1_control._trlc_dk1_rt import RtControlLoop, RtLoopConfig, MotorDescriptor, MotorType
+        except ImportError as e:
+            raise ImportError(
+                "C++ RT extension not available. Install with: "
+                "pip install -e '.[rt]'"
+            ) from e
+
+        self._config = config
+        self._RtControlLoop = RtControlLoop
+        self._loop = None
+
+        # Build RtLoopConfig from DK1RobotConfig
+        rt_cfg = RtLoopConfig()
+        rt_cfg.serial_port = config.serial_port
+        rt_cfg.loop_hz = config.motor_thread_hz
+
+        # Motor descriptors
+        motor_type_map = {
+            "DM4310": MotorType.DM4310,
+            "DM4310_48V": MotorType.DM4310_48V,
+            "DM4340": MotorType.DM4340,
+            "DM4340_48V": MotorType.DM4340_48V,
+        }
+
+        motors = []
+        for m in _DEFAULT_MOTORS:
+            desc = MotorDescriptor()
+            desc.name = m["name"]
+            desc.type = motor_type_map[m["type"]]
+            desc.slave_id = m["slave_id"]
+            desc.master_id = m["master_id"]
+            motors.append(desc)
+        rt_cfg.motors = motors
+
+        # Gains
+        rt_cfg.default_kp = np.asarray(config.arm_kp, dtype=np.float64)
+        rt_cfg.default_kd = np.asarray(config.arm_kd, dtype=np.float64)
+
+        # Joint limits (flatten from (6,2) to (12,) interleaved [lo0,hi0,...])
+        limits = np.asarray(config.joint_pos_limits, dtype=np.float64)
+        rt_cfg.joint_pos_limits = limits.flatten()
+
+        rt_cfg.joint_torque_limits = np.asarray(config.joint_torque_limits, dtype=np.float64)
+        rt_cfg.joint_velocity_limits = np.asarray(config.joint_velocity_limits, dtype=np.float64)
+        rt_cfg.max_pos_delta_per_cycle = np.asarray(config.max_pos_delta_per_cycle, dtype=np.float64)
+        rt_cfg.limit_buffer = 0.05
+
+        # Gravity compensation
+        if config.mjcf_path:
+            rt_cfg.model_path = str(Path(config.mjcf_path).resolve())
+        rt_cfg.gravity_comp_scale = config.gravity_comp_scale
+
+        # Safety
+        rt_cfg.command_timeout_s = config.command_timeout_s
+        rt_cfg.overcurrent_threshold = config.overcurrent_threshold
+        rt_cfg.overspeed_threshold = config.overspeed_threshold
+        rt_cfg.min_motors_required = config.min_motors_required
+        rt_cfg.gripper_cal_timeout_s = config.gripper_cal_timeout_s
+        rt_cfg.max_consecutive_empty_cycles = config.max_consecutive_empty_cycles
+
+        # Gripper
+        rt_cfg.gripper_open_pos = config.gripper_open_pos
+        rt_cfg.gripper_closed_pos = config.gripper_closed_pos
+        rt_cfg.max_gripper_torque_nm = config.max_gripper_torque_nm
+        rt_cfg.torque_constant = config.DM4310_TORQUE_CONSTANT
+        rt_cfg.emit_velocity_scale = config.EMIT_VELOCITY_SCALE
+        rt_cfg.emit_current_scale = config.EMIT_CURRENT_SCALE
+        rt_cfg.disable_torque_on_disconnect = config.disable_torque_on_disconnect
+
+        self._rt_cfg = rt_cfg
+
+    def connect(self) -> None:
+        """Start the C++ RT control loop."""
+        self._loop = self._RtControlLoop(self._rt_cfg)
+        self._loop.start()
+        logger.info(
+            "DK1RobotRT connected (RT active: %s)", self._loop.is_rt_active()
+        )
+
+    def disconnect(self) -> None:
+        """Stop the C++ RT control loop."""
+        if self._loop is not None:
+            self._loop.stop()
+            self._loop = None
+        logger.info("DK1RobotRT disconnected")
+
+    def command_joint_pos(self, q_des: np.ndarray) -> None:
+        """Set target joint positions for the 6 arm joints (radians)."""
+        if q_des.shape != (6,):
+            raise ValueError(f"Expected shape (6,), got {q_des.shape}")
+        if self._loop is not None:
+            self._loop.command_joint_pos(np.asarray(q_des, dtype=np.float64))
+
+    def command_gripper(self, normalized_pos: float) -> None:
+        """Set gripper target (0.0=open, 1.0=closed)."""
+        if self._loop is not None:
+            self._loop.command_gripper(float(normalized_pos))
+
+    def get_joint_state(self) -> dict[str, np.ndarray]:
+        """Return arm joint state as dict with 'pos', 'vel', 'torque' arrays."""
+        if self._loop is None:
+            return {
+                "pos": np.zeros(6),
+                "vel": np.zeros(6),
+                "torque": np.zeros(6),
+            }
+        state = self._loop.get_joint_state()
+        return {
+            "pos": np.array(state.pos),
+            "vel": np.array(state.vel),
+            "torque": np.array(state.torque),
+        }
+
+    def get_gripper_state(self) -> dict[str, float]:
+        """Return normalized gripper position and torque."""
+        if self._loop is None:
+            return {"pos": 0.0, "torque": 0.0}
+        state = self._loop.get_gripper_state()
+        return {"pos": state.pos, "torque": state.torque}
+
+    def get_perf(self):
+        """Return performance snapshot from the RT loop."""
+        if self._loop is None:
+            return None
+        return self._loop.get_perf()
+
+    def read_cycle_times(self, n: int = 10000) -> np.ndarray:
+        """Return array of recent cycle times in microseconds."""
+        if self._loop is None:
+            return np.array([], dtype=np.float32)
+        return self._loop.read_cycle_times(n)

--- a/trlc_dk1_control/rt_robot.py
+++ b/trlc_dk1_control/rt_robot.py
@@ -170,6 +170,33 @@ class DK1RobotRT:
         state = self._loop.get_gripper_state()
         return {"pos": state.pos, "torque": state.torque}
 
+    def get_state_at(self, ts_ns: int) -> dict | None:
+        """Return joint+gripper state at-or-before ``ts_ns``, or ``None`` if unavailable.
+
+        Wraps the C++ ``get_state_at`` ring lookup, flattening the result into a
+        dict shaped like ``get_joint_state()`` + ``get_gripper_state()`` combined,
+        plus the actual capture timestamp the ring used (so the caller can audit
+        how stale the alignment is).
+
+        ``None`` is returned when the requested time predates the oldest sample
+        in the ring (~1 s at 250 Hz), or when no samples have been captured yet,
+        or when the RT loop isn't running. The caller should then fall back to
+        the "latest" API.
+        """
+        if self._loop is None:
+            return None
+        snap = self._loop.get_state_at(ts_ns)
+        if snap is None:
+            return None
+        return {
+            "ts_mono_ns": snap.ts_mono_ns,
+            "joint_pos": np.array(snap.joints.pos),
+            "joint_vel": np.array(snap.joints.vel),
+            "joint_torque": np.array(snap.joints.torque),
+            "gripper_pos": snap.gripper.pos,
+            "gripper_torque": snap.gripper.torque,
+        }
+
     def get_perf(self):
         """Return performance snapshot from the RT loop."""
         if self._loop is None:

--- a/trlc_dk1_control/rt_robot.py
+++ b/trlc_dk1_control/rt_robot.py
@@ -81,8 +81,20 @@ class DK1RobotRT:
         rt_cfg.joint_pos_limits = limits.flatten()
 
         rt_cfg.joint_torque_limits = np.asarray(config.joint_torque_limits, dtype=np.float64)
-        rt_cfg.joint_velocity_limits = np.asarray(config.joint_velocity_limits, dtype=np.float64)
-        rt_cfg.max_pos_delta_per_cycle = np.asarray(config.max_pos_delta_per_cycle, dtype=np.float64)
+
+        # Apply joint_velocity_scaling to both the velocity limit (rad/s, used by the
+        # overspeed watchdog) and the per-cycle slew limit (rad/cycle, used by the
+        # impedance loop's position ramp). Without this, the Makefile's
+        # JOINT_VELOCITY_SCALING knob silently does nothing in RT mode.
+        vel_scale = float(np.clip(config.joint_velocity_scaling, 1e-3, 1.0))
+        if vel_scale != 1.0:
+            logger.info(
+                "DK1RobotRT: joint_velocity_scaling=%.3f → scaling joint_velocity_limits "
+                "and max_pos_delta_per_cycle by the same factor.",
+                vel_scale,
+            )
+        rt_cfg.joint_velocity_limits = np.asarray(config.joint_velocity_limits, dtype=np.float64) * vel_scale
+        rt_cfg.max_pos_delta_per_cycle = np.asarray(config.max_pos_delta_per_cycle, dtype=np.float64) * vel_scale
         rt_cfg.limit_buffer = 0.05
 
         # Gravity compensation


### PR DESCRIPTION
## Summary

  Hardware-side backing for the VR teleop, alignment, dashboard timing
  diagnostics, and force-haptic work landing in
  `Dream-Machines-Robotics/dreammachines#<NN>` (the `feat/vr-teleop`
  integration PR).

  7 commits + 1 main-merge · 6 files · ~+385 / −20.
  
  ## What's in this branch
  
  - **Timestamped state ring on `RtControlLoop` (`csrc/`)** —
    `get_state_at(ts_ns)` returns the joint state captured nearest to a
    given monotonic-clock timestamp. Backs the bi-follower's
    observation-alignment path: the recording loop picks a reference
    time T (newest camera kernel-capture timestamp) and asks every
    sensor for its state at T.
  - **Bi-follower / follower observation assembly with alignment.**
    When `LEROBOT_OBS_ALIGN=1`, the bi-follower picks T from the cpp
    camera daemon's most recent capture and uses `get_state_at(T)` for
    motor state. Default `OBS_ALIGN=0` matches upstream LeRobot
    semantics (latest-of-everything per tick) for minimum inference
    latency. Operator-facing knob is in ledream's `make.local`.
  - **`bi_follower.last_observation_ref_ts_ns` + `last_camera_capture_ts_ns`**
    side-channels — exposed independently of `OBS_ALIGN`. The recording
    loop reads the former to align teleop snapshots to the same T; the
    latter goes into every row of the timing side-file
    (`meta/timing/episode_NNNNNN.parquet`) so the dashboard can compute
    image staleness / image↔action skew / aliasing duplicates without
    re-decoding video.
  - **Observation-stats counter on the bi-follower** —
    `get_observation_stats()` returns `{total, aligned, ref_unchanged,
    ref_unchanged_pct}`. Lets `lerobot-record` log a one-liner per
    episode summarising how many rows the dataset will contain that
    share a reference time with the previous row (= frame-rate-aliasing
    duplicates).
  - **`get_joint_torques()` side-channel on the follower** — duck-typed
    read used by the teleop thread to push gripper-torque-driven
    haptic feedback to the leader (`make record` now gets the same
    force vibration that `make teleop` already had).
  - **Drop internal "Option C" terminology** — replaced with
    descriptive language ("timestamp-aligned observations"). The name
    only meant something inside one design discussion.

  The merge-from-main commit (`935a361`) picked up the `LEADER_HW_REV`
  env-var support for older-rev leaders that was added on `main` in
  parallel.

  ## Compatibility

  - Default behaviour unchanged: `LEROBOT_OBS_ALIGN` defaults to `0`,
    so this branch behaves like the previous tip when consumed by an
    older lerobot. The new side-channels are added as attributes —
    callers that don't look for them aren't affected.
  - C++ ABI: `csrc/` rebuild required (the timestamped state ring
    changes the in-process struct). Anyone with a stale
    `*.so`/`_dk1_csrc_core*` artifact should `make build` after
    pulling.

  ## Verification

  - All-arm-bench smoke run on the workstation rig at MJPG 720p50 × 3
    cameras through the cpp camera daemon — no corrupt-JPEG warnings,
    timing side-files populate per episode, `obs alignment` log line
    reports total/aligned/ref_unchanged as expected.
  - Standalone `make teleop TELEOP_INPUT=leader` and `make teleop
    TELEOP_INPUT=vr` both feel correct with this build.
  - `LEROBOT_OBS_ALIGN=0` and `=1` modes both record cleanly; the
    alignment-off path matches the pre-branch behaviour bit-for-bit on
    a side-by-side compare.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)