### PR TITLE
Move tool0 to flange; add tcp at grasp point

### DIFF
--- a/urdf/follower/TRLC-DK1-Follower.urdf
+++ b/urdf/follower/TRLC-DK1-Follower.urdf
@@ -392,15 +392,31 @@
       effort="20"
       velocity="0.18" />
   </joint>
+  <!-- tool0 = FLANGE (ROS-Industrial convention): link6-7 origin (wrist, zero lever)
+       with OpenCV orientation (z=approach/front, x=right). This is the effector frame
+       for cartesian actions — decouples position deltas from wrist-rotation lever.
+       tcp is a child of tool0, so its offset is a pure translation along tool-z
+       (approach). -->
   <link name="tool0" />
-  <joint name="gripper_tool0" type="fixed">
+  <joint name="tool0_joint" type="fixed">
     <origin
-      xyz="0.158 0 0"
+      xyz="0 0 0"
       rpy="-1.5707963267948966 0 -1.5707963267948966" />
     <parent
       link="link6-7" />
     <child
       link="tool0" />
+  </joint>
+  <!-- TCP / grasp point, 5mm before the finger tips (tips are at 0.158). -->
+  <link name="tcp" />
+  <joint name="tcp_joint" type="fixed">
+    <origin
+      xyz="0 0 0.153"
+      rpy="0 0 0" />
+    <parent
+      link="tool0" />
+    <child
+      link="tcp" />
   </joint>
 
   <!-- Wrist camera (sensor frame) -->


### PR DESCRIPTION
The previous tool0 link sat at the +0.158m fingertip plane, which is neither the ROS-Industrial flange frame nor the actual grasp point. Add tool0 at the link6-7 (flange) origin so cartesian actions can use a zero-lever effector frame decoupled from wrist-rotation lever, and define tcp as a child of tool0 at z=0.153, the grasp point 5mm before the finger tips. This keeps the tcp offset a pure translation along the approach axis and defines the orientation convention in a single place.