### PR TITLE
Add dynamixel and viz extras so teleop works on a fresh install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "numpy>=2.0.1",
   "pyserial>=3.5",
   "dynamixel-sdk>=3.7.31",
-  "lerobot@https://github.com/huggingface/lerobot.git",
+  "lerobot[dynamixel,viz]@https://github.com/huggingface/lerobot.git",
 ]
 
 authors = [


### PR DESCRIPTION
A default install is missing two LeRobot extras that teleop needs:
    
  - `deepdiff` — required when the Dynamixel bus is constructed, so the leader (`dk1_leader`) fails to start without it.
  - `rerun-sdk` — required for `--display_data=true`, which the documented teleop commands use.
  
  Adding the `[dynamixel,viz]` extras pulls both in (`dynamixel` → deepdiff + dynamixel-sdk/pyserial, `viz` → rerun-sdk), so the documented commands run on
  a fresh clone.