### PR TITLE
Add end-effector control pipeline (EE-space teleop/record/rollout)

### DIFF
--- a/examples/ee_record.py
+++ b/examples/ee_record.py
@@ -36,7 +36,11 @@ def main(cfg: RecordConfig) -> None:
         cfg,
         teleop_action_processor=make_leader_joints_to_ee_pipeline(leader_kin, tuple_input=True),
         robot_observation_processor=make_follower_obs_to_ee_pipeline(follower_kin),
-        robot_action_processor=make_ee_to_follower_joints_pipeline(follower_kin),
+        # initial_guess_current_joints=True matches how all datasets so far were
+        # collected — keep it pinned so recording and rollout stay consistent.
+        robot_action_processor=make_ee_to_follower_joints_pipeline(
+            follower_kin, initial_guess_current_joints=True
+        ),
     )
 
 

--- a/examples/ee_record.py
+++ b/examples/ee_record.py
@@ -36,10 +36,8 @@ def main(cfg: RecordConfig) -> None:
         cfg,
         teleop_action_processor=make_leader_joints_to_ee_pipeline(leader_kin, tuple_input=True),
         robot_observation_processor=make_follower_obs_to_ee_pipeline(follower_kin),
-        # initial_guess_current_joints=True matches how all datasets so far were
-        # collected — keep it pinned so recording and rollout stay consistent.
         robot_action_processor=make_ee_to_follower_joints_pipeline(
-            follower_kin, initial_guess_current_joints=True
+            follower_kin
         ),
     )
 

--- a/examples/ee_record.py
+++ b/examples/ee_record.py
@@ -1,0 +1,54 @@
+"""EE-space dataset recording for DK1.
+
+Thin wrapper around `lerobot.scripts.lerobot_record.record` that installs the
+EE pipelines (FK on leader joints and follower observation, IK on action) so
+the resulting dataset stores cartesian columns:
+
+    observation.state.ee.{x,y,z,wx,wy,wz,gripper_pos}
+    action.ee.{x,y,z,wx,wy,wz,gripper_pos}
+
+All CLI flags supported by `lerobot-record` work here too — `@parser.wrap()`
+re-exposes the same `RecordConfig`. Example invocation:
+
+    python examples/ee_record.py \\
+        --robot.type=dk1_follower --robot.port=/dev/ttyACM1 \\
+        --teleop.type=dk1_leader  --teleop.port=/dev/ttyACM0 \\
+        --dataset.fps=30 \\
+        --dataset.repo_id=felixmin/dk1-pick-cube-ee \\
+        --dataset.single_task="pick up the cube and place it in the bin" \\
+        --dataset.num_episodes=10 \\
+        --dataset.episode_time_s=30 \\
+        --dataset.reset_time_s=30 \\
+        --dataset.push_to_hub=false
+
+For policy-driven recording (the `--policy.path=...` case) use ee_rollout.py
+instead — `lerobot-record` is teleop-only.
+"""
+
+from lerobot.configs import parser
+from lerobot.scripts.lerobot_record import RecordConfig, record
+
+from lerobot_robot_trlc_dk1.ee_pipelines import (
+    make_dk1_kinematics,
+    make_ee_to_follower_joints_pipeline,
+    make_follower_obs_to_ee_pipeline,
+    make_leader_joints_to_ee_pipeline,
+)
+
+
+@parser.wrap()
+def main(cfg: RecordConfig) -> None:
+    # Leader and follower share the follower URDF (kinematic twins, Option A).
+    follower_kin = make_dk1_kinematics()
+    leader_kin = make_dk1_kinematics()
+
+    record(
+        cfg,
+        teleop_action_processor=make_leader_joints_to_ee_pipeline(leader_kin, tuple_input=True),
+        robot_observation_processor=make_follower_obs_to_ee_pipeline(follower_kin),
+        robot_action_processor=make_ee_to_follower_joints_pipeline(follower_kin),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ee_record.py
+++ b/examples/ee_record.py
@@ -37,7 +37,7 @@ def main(cfg: RecordConfig) -> None:
         teleop_action_processor=make_leader_joints_to_ee_pipeline(leader_kin, tuple_input=True),
         robot_observation_processor=make_follower_obs_to_ee_pipeline(follower_kin),
         robot_action_processor=make_ee_to_follower_joints_pipeline(
-            follower_kin
+            follower_kin, converge_ik=False
         ),
     )
 

--- a/examples/ee_record.py
+++ b/examples/ee_record.py
@@ -1,14 +1,8 @@
 """EE-space dataset recording for DK1.
 
-Thin wrapper around `lerobot.scripts.lerobot_record.record` that installs the
-EE pipelines (FK on leader joints and follower observation, IK on action) so
-the resulting dataset stores cartesian columns:
-
-    observation.state.ee.{x,y,z,wx,wy,wz,gripper_pos}
-    action.ee.{x,y,z,wx,wy,wz,gripper_pos}
-
-All CLI flags supported by `lerobot-record` work here too — `@parser.wrap()`
-re-exposes the same `RecordConfig`. Example invocation:
+Wraps `lerobot-record` with FK on leader joints + follower observation and IK
+on the action, so the dataset stores cartesian columns. All `lerobot-record`
+CLI flags work here.
 
     python examples/ee_record.py \\
         --robot.type=dk1_follower --robot.port=/dev/ttyACM1 \\
@@ -20,9 +14,6 @@ re-exposes the same `RecordConfig`. Example invocation:
         --dataset.episode_time_s=30 \\
         --dataset.reset_time_s=30 \\
         --dataset.push_to_hub=false
-
-For policy-driven recording (the `--policy.path=...` case) use ee_rollout.py
-instead — `lerobot-record` is teleop-only.
 """
 
 from lerobot.configs import parser
@@ -38,7 +29,6 @@ from lerobot_robot_trlc_dk1.ee_pipelines import (
 
 @parser.wrap()
 def main(cfg: RecordConfig) -> None:
-    # Leader and follower share the follower URDF (kinematic twins, Option A).
     follower_kin = make_dk1_kinematics()
     leader_kin = make_dk1_kinematics()
 

--- a/examples/ee_rollout.py
+++ b/examples/ee_rollout.py
@@ -1,0 +1,105 @@
+"""EE-space policy rollout for DK1.
+
+Replays the body of `lerobot.scripts.lerobot_rollout.rollout` with our EE
+pipelines wired into `build_rollout_context`. The stock `rollout()` calls
+`build_rollout_context(cfg, shutdown_event)` with no processor kwargs, which
+defaults to identity pipelines — that would feed the policy joint-space
+observations and try to send its EE-space outputs straight to the robot. Both
+shapes wrong.
+
+`teleop_action_processor` is also required even though there's no teleop in
+non-DAgger rollout: `build_rollout_context` runs its `transform_features` to
+derive the policy/dataset action names (see `lerobot/rollout/context.py:288`).
+Without it, action names default to `joint_*.pos` and the IK step downstream
+fails looking for `ee.x`/`ee.y`/...
+
+Re-exposes the standard `RolloutConfig` via `@parser.wrap()`, so all CLI flags
+supported by `lerobot-rollout` work here. Example:
+
+    python examples/ee_rollout.py \\
+        --robot.type=dk1_follower --robot.port=/dev/ttyACM1 \\
+        --robot.cameras="{ context: {type: opencv, index_or_path: 0, width: 640, height: 360, fps: 30, rotation: 180} }" \\
+        --policy.path=outputs/train/dk1-pick-cube-act-ee/checkpoints/020000/pretrained_model \\
+        --policy.device=mps \\
+        --policy.temporal_ensemble_coeff=0.01 \\
+        --fps=30 \\
+        --duration=300 \\
+        --task="pick up the cube and place it in the bin"
+"""
+
+import logging
+
+# Side-effect imports: register camera configs with draccus. The stock
+# `lerobot.scripts.lerobot_rollout` does the same; we bypass that script, so
+# without these `--robot.cameras="{... type: opencv ...}"` fails to parse.
+from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
+from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
+from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
+from lerobot.configs import parser
+from lerobot.rollout import RolloutConfig, build_rollout_context, create_strategy
+from lerobot.utils.process import ProcessSignalHandler
+from lerobot.utils.utils import init_logging
+from lerobot.utils.visualization_utils import init_rerun
+
+from lerobot_robot_trlc_dk1.ee_pipelines import (
+    make_dk1_kinematics,
+    make_ee_to_follower_joints_pipeline,
+    make_follower_obs_to_ee_pipeline,
+    make_leader_joints_to_ee_pipeline,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@parser.wrap()
+def main(cfg: RolloutConfig) -> None:
+    init_logging()
+
+    if cfg.display_data:
+        logger.info("Initializing Rerun visualization")
+        init_rerun(session_name="dk1_ee_rollout", ip=cfg.display_ip, port=cfg.display_port)
+
+    follower_kin = make_dk1_kinematics()
+    leader_kin = make_dk1_kinematics()
+
+    # Re-seed IK from current joints each tick: policy can produce larger jumps
+    # than leader-driven teleop, so the actual robot state is a safer seed than
+    # the previous IK solution.
+    signal_handler = ProcessSignalHandler(use_threads=True, display_pid=False)
+    shutdown_event = signal_handler.shutdown_event
+
+    logger.info("Building rollout context with EE pipelines...")
+    ctx = build_rollout_context(
+        cfg,
+        shutdown_event,
+        teleop_action_processor=make_leader_joints_to_ee_pipeline(leader_kin, tuple_input=True),
+        robot_action_processor=make_ee_to_follower_joints_pipeline(
+            follower_kin, safety=False, initial_guess_current_joints=True
+        ),
+        robot_observation_processor=make_follower_obs_to_ee_pipeline(follower_kin),
+    )
+
+    strategy = create_strategy(cfg.strategy)
+    logger.info("Rollout strategy: %s", cfg.strategy.type)
+    logger.info(
+        "Robot: %s | FPS: %.0f | Duration: %s",
+        cfg.robot.type if cfg.robot else "?",
+        cfg.fps,
+        f"{cfg.duration}s" if cfg.duration > 0 else "infinite",
+    )
+
+    try:
+        strategy.setup(ctx)
+        logger.info("Rollout setup complete, starting rollout...")
+        strategy.run(ctx)
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+    finally:
+        strategy.teardown(ctx)
+
+    logger.info("Rollout finished")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ee_rollout.py
+++ b/examples/ee_rollout.py
@@ -6,9 +6,8 @@ Replays `lerobot-rollout`'s body with EE pipelines wired into
     python examples/ee_rollout.py \\
         --robot.type=dk1_follower --robot.port=/dev/ttyACM1 \\
         --robot.cameras="{ context: {type: opencv, index_or_path: 0, width: 640, height: 360, fps: 30, rotation: 180} }" \\
-        --policy.path=outputs/train/dk1-pick-cube-act-ee/checkpoints/020000/pretrained_model \\
-        --policy.device=mps \\
-        --policy.temporal_ensemble_coeff=0.01 \\
+        --policy.path=outputs/train/dk1-pick-cube-diffusion-ee/checkpoints/last/pretrained_model \\
+        --device=cuda \\
         --fps=30 \\
         --duration=300 \\
         --task="pick up the cube and place it in the bin"
@@ -57,7 +56,7 @@ def main(cfg: RolloutConfig) -> None:
         shutdown_event,
         teleop_action_processor=make_leader_joints_to_ee_pipeline(leader_kin, tuple_input=True),
         robot_action_processor=make_ee_to_follower_joints_pipeline(
-            follower_kin, safety=False
+            follower_kin, safety=True, initial_guess_current_joints=True
         ),
         robot_observation_processor=make_follower_obs_to_ee_pipeline(follower_kin),
     )

--- a/examples/ee_rollout.py
+++ b/examples/ee_rollout.py
@@ -1,20 +1,7 @@
 """EE-space policy rollout for DK1.
 
-Replays the body of `lerobot.scripts.lerobot_rollout.rollout` with our EE
-pipelines wired into `build_rollout_context`. The stock `rollout()` calls
-`build_rollout_context(cfg, shutdown_event)` with no processor kwargs, which
-defaults to identity pipelines — that would feed the policy joint-space
-observations and try to send its EE-space outputs straight to the robot. Both
-shapes wrong.
-
-`teleop_action_processor` is also required even though there's no teleop in
-non-DAgger rollout: `build_rollout_context` runs its `transform_features` to
-derive the policy/dataset action names (see `lerobot/rollout/context.py:288`).
-Without it, action names default to `joint_*.pos` and the IK step downstream
-fails looking for `ee.x`/`ee.y`/...
-
-Re-exposes the standard `RolloutConfig` via `@parser.wrap()`, so all CLI flags
-supported by `lerobot-rollout` work here. Example:
+Replays `lerobot-rollout`'s body with EE pipelines wired into
+`build_rollout_context`. All `lerobot-rollout` CLI flags work here.
 
     python examples/ee_rollout.py \\
         --robot.type=dk1_follower --robot.port=/dev/ttyACM1 \\
@@ -29,9 +16,7 @@ supported by `lerobot-rollout` work here. Example:
 
 import logging
 
-# Side-effect imports: register camera configs with draccus. The stock
-# `lerobot.scripts.lerobot_rollout` does the same; we bypass that script, so
-# without these `--robot.cameras="{... type: opencv ...}"` fails to parse.
+# Side-effect imports: register camera configs with draccus, as lerobot_rollout does.
 from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
 from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
 from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
@@ -57,19 +42,14 @@ def main(cfg: RolloutConfig) -> None:
     init_logging()
 
     if cfg.display_data:
-        logger.info("Initializing Rerun visualization")
         init_rerun(session_name="dk1_ee_rollout", ip=cfg.display_ip, port=cfg.display_port)
 
     follower_kin = make_dk1_kinematics()
     leader_kin = make_dk1_kinematics()
 
-    # Re-seed IK from current joints each tick: policy can produce larger jumps
-    # than leader-driven teleop, so the actual robot state is a safer seed than
-    # the previous IK solution.
     signal_handler = ProcessSignalHandler(use_threads=True, display_pid=False)
     shutdown_event = signal_handler.shutdown_event
 
-    logger.info("Building rollout context with EE pipelines...")
     ctx = build_rollout_context(
         cfg,
         shutdown_event,
@@ -81,24 +61,17 @@ def main(cfg: RolloutConfig) -> None:
     )
 
     strategy = create_strategy(cfg.strategy)
-    logger.info("Rollout strategy: %s", cfg.strategy.type)
-    logger.info(
-        "Robot: %s | FPS: %.0f | Duration: %s",
-        cfg.robot.type if cfg.robot else "?",
-        cfg.fps,
-        f"{cfg.duration}s" if cfg.duration > 0 else "infinite",
-    )
+    logger.info("Rollout strategy: %s | FPS: %.0f | Duration: %s",
+                cfg.strategy.type, cfg.fps,
+                f"{cfg.duration}s" if cfg.duration > 0 else "infinite")
 
     try:
         strategy.setup(ctx)
-        logger.info("Rollout setup complete, starting rollout...")
         strategy.run(ctx)
     except KeyboardInterrupt:
         logger.info("Interrupted by user")
     finally:
         strategy.teardown(ctx)
-
-    logger.info("Rollout finished")
 
 
 if __name__ == "__main__":

--- a/examples/ee_rollout.py
+++ b/examples/ee_rollout.py
@@ -32,6 +32,8 @@ from lerobot_robot_trlc_dk1.ee_pipelines import (
     make_follower_obs_to_ee_pipeline,
     make_leader_joints_to_ee_pipeline,
 )
+# Side-effect import: registers --inference.type=sync_relative for relative-action policies.
+from lerobot_robot_trlc_dk1 import sync_relative_inference  # noqa: F401
 
 
 logger = logging.getLogger(__name__)
@@ -55,7 +57,7 @@ def main(cfg: RolloutConfig) -> None:
         shutdown_event,
         teleop_action_processor=make_leader_joints_to_ee_pipeline(leader_kin, tuple_input=True),
         robot_action_processor=make_ee_to_follower_joints_pipeline(
-            follower_kin, safety=False, initial_guess_current_joints=True
+            follower_kin, safety=False
         ),
         robot_observation_processor=make_follower_obs_to_ee_pipeline(follower_kin),
     )

--- a/examples/ee_teleop.py
+++ b/examples/ee_teleop.py
@@ -31,7 +31,7 @@ def main(cfg: TeleoperateConfig) -> None:
     leader_kin = make_dk1_kinematics()
 
     leader_to_ee = make_leader_joints_to_ee_pipeline(leader_kin, tuple_input=False)
-    ee_to_follower = make_ee_to_follower_joints_pipeline(follower_kin)
+    ee_to_follower = make_ee_to_follower_joints_pipeline(follower_kin, initial_guess_current_joints=True)
 
     leader.connect()
     follower.connect()

--- a/examples/ee_teleop.py
+++ b/examples/ee_teleop.py
@@ -1,0 +1,87 @@
+"""Leader→follower teleop in EE space, via LeRobot's native processor pipeline.
+
+Mirrors `lerobot/examples/so100_to_so100_EE/teleoperate.py`. Each tick:
+
+    leader joints  ──FK──▶  ee.x..wz, ee.gripper_pos  ──IK──▶  follower joints
+
+The leader and follower share the follower URDF (Option A — both are kinematic
+twins of the same chain). FK on the leader runs through the follower's link
+lengths; IK puts those targets back on the follower. Functionally close to plain
+joint-space teleop but routes through the standard LeRobot EE pipeline, so the
+same pipeline classes drop into recording / training / rollout unchanged.
+
+Compared to the existing joint-space `examples/teleop.py`, this adds:
+  - EE-space safety bounds (workspace clip + per-step jump cap).
+  - placo IK every tick instead of forwarding raw joints.
+  - Reusable plumbing for recording EE-space datasets.
+"""
+
+import argparse
+import logging
+import time
+
+from lerobot.utils.robot_utils import precise_sleep
+from lerobot.utils.utils import init_logging
+from lerobot.utils.visualization_utils import init_rerun, log_rerun_data
+
+from lerobot_robot_trlc_dk1.ee_pipelines import (
+    make_dk1_kinematics,
+    make_ee_to_follower_joints_pipeline,
+    make_leader_joints_to_ee_pipeline,
+)
+from lerobot_robot_trlc_dk1.follower import DK1Follower, DK1FollowerConfig
+from lerobot_robot_trlc_dk1.leader import DK1Leader, DK1LeaderConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="EE-space teleop for DK1 leader → follower.")
+    p.add_argument("--follower-port", default="/dev/ttyACM1")
+    p.add_argument("--leader-port", default="/dev/ttyACM0")
+    p.add_argument("--fps", type=int, default=30)
+    return p.parse_args()
+
+
+def main() -> None:
+    init_logging()
+    args = _parse_args()
+
+    follower = DK1Follower(DK1FollowerConfig(port=args.follower_port))
+    leader = DK1Leader(DK1LeaderConfig(port=args.leader_port))
+
+    follower_kin = make_dk1_kinematics()
+    leader_kin = make_dk1_kinematics()
+
+    leader_to_ee = make_leader_joints_to_ee_pipeline(leader_kin, tuple_input=False)
+    ee_to_follower = make_ee_to_follower_joints_pipeline(follower_kin)
+
+    leader.connect()
+    follower.connect()
+    init_rerun(session_name="dk1_ee_teleop")
+
+    logger.info("Starting EE teleop loop. Ctrl-C to stop.")
+    try:
+        while True:
+            t0 = time.perf_counter()
+
+            robot_obs = follower.get_observation()
+            leader_joints = leader.get_action()
+
+            ee_action = leader_to_ee(leader_joints)
+            follower_action = ee_to_follower((ee_action, robot_obs))
+
+            follower.send_action(follower_action)
+
+            log_rerun_data(observation=ee_action, action=follower_action)
+            precise_sleep(max(1.0 / args.fps - (time.perf_counter() - t0), 0.0))
+    except KeyboardInterrupt:
+        logger.info("Stopping teleop...")
+    finally:
+        leader.disconnect()
+        follower.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ee_teleop.py
+++ b/examples/ee_teleop.py
@@ -1,27 +1,18 @@
-"""Leader→follower teleop in EE space, via LeRobot's native processor pipeline.
+"""Leader→follower teleop in EE space (FK on leader, IK on follower).
 
-Mirrors `lerobot/examples/so100_to_so100_EE/teleoperate.py`. Each tick:
-
-    leader joints  ──FK──▶  ee.x..wz, ee.gripper_pos  ──IK──▶  follower joints
-
-The leader and follower share the follower URDF (Option A — both are kinematic
-twins of the same chain). FK on the leader runs through the follower's link
-lengths; IK puts those targets back on the follower. Functionally close to plain
-joint-space teleop but routes through the standard LeRobot EE pipeline, so the
-same pipeline classes drop into recording / training / rollout unchanged.
-
-Compared to the existing joint-space `examples/teleop.py`, this adds:
-  - EE-space safety bounds (workspace clip + per-step jump cap).
-  - placo IK every tick instead of forwarding raw joints.
-  - Reusable plumbing for recording EE-space datasets.
+    python examples/ee_teleop.py \\
+        --robot.type=dk1_follower --robot.port=/dev/ttyACM1 \\
+        --teleop.type=dk1_leader  --teleop.port=/dev/ttyACM0 \\
+        --fps=30
 """
 
-import argparse
-import logging
 import time
 
+from lerobot.configs import parser
+from lerobot.robots import make_robot_from_config
+from lerobot.scripts.lerobot_teleoperate import TeleoperateConfig
+from lerobot.teleoperators import make_teleoperator_from_config
 from lerobot.utils.robot_utils import precise_sleep
-from lerobot.utils.utils import init_logging
 from lerobot.utils.visualization_utils import init_rerun, log_rerun_data
 
 from lerobot_robot_trlc_dk1.ee_pipelines import (
@@ -29,27 +20,12 @@ from lerobot_robot_trlc_dk1.ee_pipelines import (
     make_ee_to_follower_joints_pipeline,
     make_leader_joints_to_ee_pipeline,
 )
-from lerobot_robot_trlc_dk1.follower import DK1Follower, DK1FollowerConfig
-from lerobot_robot_trlc_dk1.leader import DK1Leader, DK1LeaderConfig
 
 
-logger = logging.getLogger(__name__)
-
-
-def _parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="EE-space teleop for DK1 leader → follower.")
-    p.add_argument("--follower-port", default="/dev/ttyACM1")
-    p.add_argument("--leader-port", default="/dev/ttyACM0")
-    p.add_argument("--fps", type=int, default=30)
-    return p.parse_args()
-
-
-def main() -> None:
-    init_logging()
-    args = _parse_args()
-
-    follower = DK1Follower(DK1FollowerConfig(port=args.follower_port))
-    leader = DK1Leader(DK1LeaderConfig(port=args.leader_port))
+@parser.wrap()
+def main(cfg: TeleoperateConfig) -> None:
+    follower = make_robot_from_config(cfg.robot)
+    leader = make_teleoperator_from_config(cfg.teleop)
 
     follower_kin = make_dk1_kinematics()
     leader_kin = make_dk1_kinematics()
@@ -61,7 +37,6 @@ def main() -> None:
     follower.connect()
     init_rerun(session_name="dk1_ee_teleop")
 
-    logger.info("Starting EE teleop loop. Ctrl-C to stop.")
     try:
         while True:
             t0 = time.perf_counter()
@@ -75,9 +50,9 @@ def main() -> None:
             follower.send_action(follower_action)
 
             log_rerun_data(observation=ee_action, action=follower_action)
-            precise_sleep(max(1.0 / args.fps - (time.perf_counter() - t0), 0.0))
+            precise_sleep(max(1.0 / cfg.fps - (time.perf_counter() - t0), 0.0))
     except KeyboardInterrupt:
-        logger.info("Stopping teleop...")
+        print("\nStopping teleop...")
     finally:
         leader.disconnect()
         follower.disconnect()

--- a/lerobot_robot_trlc_dk1/ee_pipelines.py
+++ b/lerobot_robot_trlc_dk1/ee_pipelines.py
@@ -1,28 +1,4 @@
-"""EE-space pipeline builders for DK1.
-
-Wraps LeRobot's `RobotProcessorPipeline` with the right converters and steps
-for DK1's three EE workflows (teleop / record / rollout) so the example scripts
-can't drift on URDF paths, joint names, EE safety bounds, or converter shapes.
-
-The three pipelines are:
-
-    leader joints      ──FK──▶  ee.*           (teleop_action_processor)
-    follower joints    ──FK──▶  observation.state.ee.*  (robot_observation_processor)
-    ee.* + follower obs ─IK─▶  follower joints (robot_action_processor)
-
-`record` and DAgger-rollout strategies invoke `teleop_action_processor((act, obs))`
-with a tuple — see `lerobot/scripts/lerobot_record.py:292` and `:302`,
-`lerobot/rollout/strategies/dagger.py:488`. The leader-FK pipeline therefore
-needs a tuple-aware `to_transition` that drops the observation; otherwise
-`ForwardKinematicsJointsToEE` would also FK the follower observation through
-the leader kinematics (a wasted placo solve, since `transition_to_robot_action`
-discards the observation anyway).
-
-Plain teleop (`examples/ee_teleop.py`) calls the pipeline with a single action
-dict, so it uses the standard single-arg converter.
-"""
-
-from __future__ import annotations
+"""EE-space pipeline builders for DK1 record / rollout / teleop."""
 
 from pathlib import Path
 from typing import Any
@@ -67,11 +43,6 @@ def _action_only_from_tuple(action_observation: tuple[Any, Any]) -> Any:
 def make_leader_joints_to_ee_pipeline(
     kinematics: DK1RobotKinematics, *, tuple_input: bool
 ) -> RobotProcessorPipeline:
-    """FK on leader joints → EE-space action.
-
-    `tuple_input=True` for record/rollout (LeRobot hands a `(act, obs)` tuple).
-    `tuple_input=False` for plain teleop (caller passes the action dict directly).
-    """
     return RobotProcessorPipeline(
         steps=[ForwardKinematicsJointsToEE(kinematics=kinematics, motor_names=MOTOR_NAMES)],
         to_transition=_action_only_from_tuple if tuple_input else robot_action_to_transition,
@@ -93,16 +64,6 @@ def make_ee_to_follower_joints_pipeline(
     safety: bool = True,
     initial_guess_current_joints: bool = False,
 ) -> RobotProcessorPipeline:
-    """IK on EE-space action → follower joint command.
-
-    `safety=False` for rollout: `EEBoundsAndSafety` raises on out-of-bounds,
-    which would abort the run if the policy ever predicts slightly beyond.
-
-    `initial_guess_current_joints=False` (the default) seeds IK with the
-    previous solution — smooth, appropriate for continuous leader-driven
-    motion. `True` re-seeds from the robot's current joints every tick, which
-    is safer if the upstream command can jump (e.g. policy rollout).
-    """
     steps: list[Any] = []
     if safety:
         steps.append(EEBoundsAndSafety(end_effector_bounds=EE_BOUNDS, max_ee_step_m=MAX_EE_STEP_M))

--- a/lerobot_robot_trlc_dk1/ee_pipelines.py
+++ b/lerobot_robot_trlc_dk1/ee_pipelines.py
@@ -1,0 +1,120 @@
+"""EE-space pipeline builders for DK1.
+
+Wraps LeRobot's `RobotProcessorPipeline` with the right converters and steps
+for DK1's three EE workflows (teleop / record / rollout) so the example scripts
+can't drift on URDF paths, joint names, EE safety bounds, or converter shapes.
+
+The three pipelines are:
+
+    leader joints      ──FK──▶  ee.*           (teleop_action_processor)
+    follower joints    ──FK──▶  observation.state.ee.*  (robot_observation_processor)
+    ee.* + follower obs ─IK─▶  follower joints (robot_action_processor)
+
+`record` and DAgger-rollout strategies invoke `teleop_action_processor((act, obs))`
+with a tuple — see `lerobot/scripts/lerobot_record.py:292` and `:302`,
+`lerobot/rollout/strategies/dagger.py:488`. The leader-FK pipeline therefore
+needs a tuple-aware `to_transition` that drops the observation; otherwise
+`ForwardKinematicsJointsToEE` would also FK the follower observation through
+the leader kinematics (a wasted placo solve, since `transition_to_robot_action`
+discards the observation anyway).
+
+Plain teleop (`examples/ee_teleop.py`) calls the pipeline with a single action
+dict, so it uses the standard single-arg converter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lerobot.processor import (
+    RobotProcessorPipeline,
+    observation_to_transition,
+    robot_action_observation_to_transition,
+    robot_action_to_transition,
+    transition_to_observation,
+    transition_to_robot_action,
+)
+from lerobot.robots.so_follower.robot_kinematic_processor import (
+    EEBoundsAndSafety,
+    ForwardKinematicsJointsToEE,
+    InverseKinematicsEEToJoints,
+)
+
+from lerobot_robot_trlc_dk1.kinematics import DK1RobotKinematics
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+URDF_PATH = str(_REPO_ROOT / "urdf" / "follower" / "TRLC-DK1-Follower.urdf")
+TARGET_FRAME = "tool0"
+JOINT_NAMES = ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
+MOTOR_NAMES = JOINT_NAMES + ["gripper"]
+
+# Generous starting bounds — tighten after a calibration session.
+EE_BOUNDS = {"min": [-1.0, -1.0, -1.0], "max": [1.0, 1.0, 1.0]}
+MAX_EE_STEP_M = 0.10
+
+
+def make_dk1_kinematics() -> DK1RobotKinematics:
+    return DK1RobotKinematics(URDF_PATH, TARGET_FRAME, JOINT_NAMES)
+
+
+def _action_only_from_tuple(action_observation: tuple[Any, Any]) -> Any:
+    action, _observation = action_observation
+    return robot_action_to_transition(action)
+
+
+def make_leader_joints_to_ee_pipeline(
+    kinematics: DK1RobotKinematics, *, tuple_input: bool
+) -> RobotProcessorPipeline:
+    """FK on leader joints → EE-space action.
+
+    `tuple_input=True` for record/rollout (LeRobot hands a `(act, obs)` tuple).
+    `tuple_input=False` for plain teleop (caller passes the action dict directly).
+    """
+    return RobotProcessorPipeline(
+        steps=[ForwardKinematicsJointsToEE(kinematics=kinematics, motor_names=MOTOR_NAMES)],
+        to_transition=_action_only_from_tuple if tuple_input else robot_action_to_transition,
+        to_output=transition_to_robot_action,
+    )
+
+
+def make_follower_obs_to_ee_pipeline(kinematics: DK1RobotKinematics) -> RobotProcessorPipeline:
+    return RobotProcessorPipeline(
+        steps=[ForwardKinematicsJointsToEE(kinematics=kinematics, motor_names=MOTOR_NAMES)],
+        to_transition=observation_to_transition,
+        to_output=transition_to_observation,
+    )
+
+
+def make_ee_to_follower_joints_pipeline(
+    kinematics: DK1RobotKinematics,
+    *,
+    safety: bool = True,
+    initial_guess_current_joints: bool = False,
+) -> RobotProcessorPipeline:
+    """IK on EE-space action → follower joint command.
+
+    `safety=False` for rollout: `EEBoundsAndSafety` raises on out-of-bounds,
+    which would abort the run if the policy ever predicts slightly beyond.
+
+    `initial_guess_current_joints=False` (the default) seeds IK with the
+    previous solution — smooth, appropriate for continuous leader-driven
+    motion. `True` re-seeds from the robot's current joints every tick, which
+    is safer if the upstream command can jump (e.g. policy rollout).
+    """
+    steps: list[Any] = []
+    if safety:
+        steps.append(EEBoundsAndSafety(end_effector_bounds=EE_BOUNDS, max_ee_step_m=MAX_EE_STEP_M))
+    steps.append(
+        InverseKinematicsEEToJoints(
+            kinematics=kinematics,
+            motor_names=MOTOR_NAMES,
+            initial_guess_current_joints=initial_guess_current_joints,
+        )
+    )
+    return RobotProcessorPipeline(
+        steps=steps,
+        to_transition=robot_action_observation_to_transition,
+        to_output=transition_to_robot_action,
+    )

--- a/lerobot_robot_trlc_dk1/ee_pipelines.py
+++ b/lerobot_robot_trlc_dk1/ee_pipelines.py
@@ -66,7 +66,7 @@ def make_ee_to_follower_joints_pipeline(
     kinematics: DK1RobotKinematics,
     *,
     safety: bool = True,
-    initial_guess_current_joints: bool = False,
+    initial_guess_current_joints: bool = True,
 ) -> RobotProcessorPipeline:
     steps: list[Any] = []
     if safety:

--- a/lerobot_robot_trlc_dk1/ee_pipelines.py
+++ b/lerobot_robot_trlc_dk1/ee_pipelines.py
@@ -32,10 +32,22 @@ MAX_EE_STEP_M = 0.10
 
 
 def make_dk1_kinematics(
-    *, kinetic_reg: float | None = 1e-4, solver_dt: float = 1 / 30
+    *,
+    kinetic_reg: float | None = 1e-4,
+    solver_dt: float = 1 / 30,
+    ik_max_iters: int = 20,
+    ik_pos_tol: float = 1e-3,
+    ik_ori_tol: float = 1e-2,
 ) -> DK1RobotKinematics:
     return DK1RobotKinematics(
-        URDF_PATH, TARGET_FRAME, JOINT_NAMES, kinetic_reg=kinetic_reg, solver_dt=solver_dt
+        URDF_PATH,
+        TARGET_FRAME,
+        JOINT_NAMES,
+        kinetic_reg=kinetic_reg,
+        solver_dt=solver_dt,
+        ik_max_iters=ik_max_iters,
+        ik_pos_tol=ik_pos_tol,
+        ik_ori_tol=ik_ori_tol,
     )
 
 
@@ -67,7 +79,9 @@ def make_ee_to_follower_joints_pipeline(
     *,
     safety: bool = True,
     initial_guess_current_joints: bool = True,
+    converge_ik: bool = False,
 ) -> RobotProcessorPipeline:
+    kinematics.converge_ik = converge_ik
     steps: list[Any] = []
     if safety:
         steps.append(EEBoundsAndSafety(end_effector_bounds=EE_BOUNDS, max_ee_step_m=MAX_EE_STEP_M))

--- a/lerobot_robot_trlc_dk1/ee_pipelines.py
+++ b/lerobot_robot_trlc_dk1/ee_pipelines.py
@@ -31,8 +31,12 @@ EE_BOUNDS = {"min": [-1.0, -1.0, -1.0], "max": [1.0, 1.0, 1.0]}
 MAX_EE_STEP_M = 0.10
 
 
-def make_dk1_kinematics() -> DK1RobotKinematics:
-    return DK1RobotKinematics(URDF_PATH, TARGET_FRAME, JOINT_NAMES)
+def make_dk1_kinematics(
+    *, kinetic_reg: float | None = 1e-4, solver_dt: float = 1 / 30
+) -> DK1RobotKinematics:
+    return DK1RobotKinematics(
+        URDF_PATH, TARGET_FRAME, JOINT_NAMES, kinetic_reg=kinetic_reg, solver_dt=solver_dt
+    )
 
 
 def _action_only_from_tuple(action_observation: tuple[Any, Any]) -> Any:

--- a/lerobot_robot_trlc_dk1/follower.py
+++ b/lerobot_robot_trlc_dk1/follower.py
@@ -130,17 +130,22 @@ class DK1Follower(Robot):
         if self.is_connected:
             raise DeviceAlreadyConnectedError(f"{self} already connected")
 
-        if self.config.control_mode == "impedance":
-            from trlc_dk1_control import DK1Robot, DK1_DEFAULT_CONFIG
-            cfg = DK1_DEFAULT_CONFIG(self.config.port)
-            cfg.max_gripper_torque_nm = self.config.max_gripper_torque
-            self._robot = DK1Robot(cfg)
-            self._robot.connect()
-        else:
-            self._connect_pos_vel()
+        try:
+            if self.config.control_mode == "impedance":
+                from trlc_dk1_control import DK1Robot, DK1_DEFAULT_CONFIG
+                cfg = DK1_DEFAULT_CONFIG(self.config.port)
+                cfg.max_gripper_torque_nm = self.config.max_gripper_torque
+                self._robot = DK1Robot(cfg)
+                self._robot.connect()
+            else:
+                self._connect_pos_vel()
 
-        for cam in self.cameras.values():
-            cam.connect()
+            for cam in self.cameras.values():
+                cam.connect()
+        except Exception:
+            logger.exception("Failed to connect %s; cleaning up connected resources.", self)
+            self._disconnect_connected_parts()
+            raise
 
         logger.info(f"{self} connected (mode={self.config.control_mode}).")
 
@@ -303,21 +308,36 @@ class DK1Follower(Robot):
         if not self.is_connected:
             raise DeviceNotConnectedError(f"{self} is not connected.")
 
+        self._disconnect_connected_parts()
+
+        logger.info(f"{self} disconnected.")
+
+    def _disconnect_connected_parts(self) -> None:
+        for cam in self.cameras.values():
+            if cam.is_connected:
+                try:
+                    cam.disconnect()
+                except Exception:
+                    logger.exception("Failed to disconnect camera %s during cleanup.", cam)
+
         if self.config.control_mode == "impedance":
-            self._robot.disconnect()
-            self._robot = None
+            if self._robot is not None:
+                try:
+                    self._robot.disconnect()
+                except Exception:
+                    logger.exception("Failed to disconnect impedance robot during cleanup.")
+                self._robot = None
         else:
-            if self.config.disable_torque_on_disconnect:
-                for motor in self._motors.values():
-                    self._control.disable(motor)
-            else:
-                self._serial_device.close()
+            if self._bus_connected:
+                try:
+                    if self.config.disable_torque_on_disconnect:
+                        for motor in self._motors.values():
+                            self._control.disable(motor)
+                    else:
+                        self._serial_device.close()
+                except Exception:
+                    logger.exception("Failed to disconnect POS_VEL bus during cleanup.")
             self._bus_connected = False
             self._motors = None
             self._control = None
             self._serial_device = None
-
-        for cam in self.cameras.values():
-            cam.disconnect()
-
-        logger.info(f"{self} disconnected.")

--- a/lerobot_robot_trlc_dk1/follower.py
+++ b/lerobot_robot_trlc_dk1/follower.py
@@ -56,6 +56,7 @@ class DK1FollowerConfig(RobotConfig):
     max_gripper_torque: float = 1.0         # Nm
     disable_torque_on_disconnect: bool = False
     cameras: dict[str, CameraConfig] = field(default_factory=dict)
+    camera_read_timeout_ms: int = 1000
     # POS_VEL mode only
     joint_velocity_scaling: float = 0.2
 
@@ -235,7 +236,7 @@ class DK1Follower(Robot):
             obs = self._get_observation_pos_vel()
 
         for cam_key, cam in self.cameras.items():
-            obs[cam_key] = cam.async_read()
+            obs[cam_key] = cam.async_read(timeout_ms=self.config.camera_read_timeout_ms)
 
         return obs
 

--- a/lerobot_robot_trlc_dk1/kinematics.py
+++ b/lerobot_robot_trlc_dk1/kinematics.py
@@ -14,11 +14,19 @@ class DK1RobotKinematics(RobotKinematics):
         *,
         kinetic_reg: float | None = 1e-4,
         solver_dt: float = 1 / 30,
+        converge_ik: bool = False,
+        ik_max_iters: int = 20,
+        ik_pos_tol: float = 1e-3,
+        ik_ori_tol: float = 1e-2,
     ):
         super().__init__(urdf_path, target_frame_name, joint_names)
         self.solver.dt = solver_dt
         if kinetic_reg is not None:
             self.solver.add_kinetic_energy_regularization_task(kinetic_reg)
+        self.converge_ik = converge_ik
+        self.ik_max_iters = ik_max_iters
+        self.ik_pos_tol = ik_pos_tol
+        self.ik_ori_tol = ik_ori_tol
 
     def forward_kinematics(self, joint_pos_rad: np.ndarray) -> np.ndarray:
         q = np.asarray(joint_pos_rad, dtype=float)
@@ -52,8 +60,19 @@ class DK1RobotKinematics(RobotKinematics):
         self.tip_frame.configure(
             self.target_frame_name, "soft", position_weight, orientation_weight
         )
-        self.solver.solve(True)
-        self.robot.update_kinematics()
+
+        max_iters = self.ik_max_iters if self.converge_ik else 1
+        for _ in range(max_iters):
+            self.solver.solve(True)
+            self.robot.update_kinematics()
+            if not self.converge_ik:
+                break
+            t_now = self.robot.get_T_world_frame(self.target_frame_name)
+            pos_err = float(np.linalg.norm(t_now[:3, 3] - desired_ee_pose[:3, 3]))
+            r_err = t_now[:3, :3].T @ desired_ee_pose[:3, :3]
+            ori_err = float(np.arccos(np.clip((np.trace(r_err) - 1.0) / 2.0, -1.0, 1.0)))
+            if pos_err <= self.ik_pos_tol and ori_err <= self.ik_ori_tol:
+                break
 
         q_out = np.array(
             [self.robot.get_joint(name) for name in self.joint_names], dtype=float

--- a/lerobot_robot_trlc_dk1/kinematics.py
+++ b/lerobot_robot_trlc_dk1/kinematics.py
@@ -6,6 +6,20 @@ from lerobot.model.kinematics import RobotKinematics
 
 
 class DK1RobotKinematics(RobotKinematics):
+    def __init__(
+        self,
+        urdf_path: str,
+        target_frame_name: str,
+        joint_names: list[str] | None = None,
+        *,
+        kinetic_reg: float | None = 1e-4,
+        solver_dt: float = 1 / 30,
+    ):
+        super().__init__(urdf_path, target_frame_name, joint_names)
+        self.solver.dt = solver_dt
+        if kinetic_reg is not None:
+            self.solver.add_kinetic_energy_regularization_task(kinetic_reg)
+
     def forward_kinematics(self, joint_pos_rad: np.ndarray) -> np.ndarray:
         q = np.asarray(joint_pos_rad, dtype=float)
         n = len(self.joint_names)

--- a/lerobot_robot_trlc_dk1/kinematics.py
+++ b/lerobot_robot_trlc_dk1/kinematics.py
@@ -1,12 +1,4 @@
-"""DK1 kinematics shim — radian I/O over LeRobot's placo-backed RobotKinematics.
-
-LeRobot's `RobotKinematics` assumes joint angles are in **degrees** on both input
-and output. DK1's DM-series follower motors and the Dynamixel leader both report
-positions in **radians**, so this subclass overrides FK and IK to skip the
-deg↔rad conversions. Defaults otherwise match upstream (see `inverse_kinematics`).
-"""
-
-from __future__ import annotations
+"""DK1 kinematics shim — radian I/O over LeRobot's placo-backed RobotKinematics."""
 
 import numpy as np
 
@@ -14,15 +6,11 @@ from lerobot.model.kinematics import RobotKinematics
 
 
 class DK1RobotKinematics(RobotKinematics):
-    """placo-backed FK/IK for DK1 with radian I/O instead of degrees."""
-
     def forward_kinematics(self, joint_pos_rad: np.ndarray) -> np.ndarray:
         q = np.asarray(joint_pos_rad, dtype=float)
         n = len(self.joint_names)
         if q.size < n:
-            raise ValueError(
-                f"forward_kinematics: need at least {n} joint angles, got {q.size}"
-            )
+            raise ValueError(f"forward_kinematics: need at least {n} joint angles, got {q.size}")
         q = q[:n]
         for name, val in zip(self.joint_names, q):
             self.robot.set_joint(name, float(val))
@@ -57,9 +45,8 @@ class DK1RobotKinematics(RobotKinematics):
             [self.robot.get_joint(name) for name in self.joint_names], dtype=float
         )
 
-        # Preserve any trailing entries (e.g. gripper) the caller passed in.
-        if current.size > len(self.joint_names):
+        if current.size > n:
             result = current.copy()
-            result[: len(self.joint_names)] = q_out
+            result[:n] = q_out
             return result
         return q_out

--- a/lerobot_robot_trlc_dk1/kinematics.py
+++ b/lerobot_robot_trlc_dk1/kinematics.py
@@ -1,0 +1,65 @@
+"""DK1 kinematics shim — radian I/O over LeRobot's placo-backed RobotKinematics.
+
+LeRobot's `RobotKinematics` assumes joint angles are in **degrees** on both input
+and output. DK1's DM-series follower motors and the Dynamixel leader both report
+positions in **radians**, so this subclass overrides FK and IK to skip the
+deg↔rad conversions. Defaults otherwise match upstream (see `inverse_kinematics`).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from lerobot.model.kinematics import RobotKinematics
+
+
+class DK1RobotKinematics(RobotKinematics):
+    """placo-backed FK/IK for DK1 with radian I/O instead of degrees."""
+
+    def forward_kinematics(self, joint_pos_rad: np.ndarray) -> np.ndarray:
+        q = np.asarray(joint_pos_rad, dtype=float)
+        n = len(self.joint_names)
+        if q.size < n:
+            raise ValueError(
+                f"forward_kinematics: need at least {n} joint angles, got {q.size}"
+            )
+        q = q[:n]
+        for name, val in zip(self.joint_names, q):
+            self.robot.set_joint(name, float(val))
+        self.robot.update_kinematics()
+        return self.robot.get_T_world_frame(self.target_frame_name)
+
+    def inverse_kinematics(
+        self,
+        current_joint_pos: np.ndarray,
+        desired_ee_pose: np.ndarray,
+        position_weight: float = 1.0,
+        orientation_weight: float = 0.01,
+    ) -> np.ndarray:
+        current = np.asarray(current_joint_pos, dtype=float)
+        n = len(self.joint_names)
+        if current.size < n:
+            raise ValueError(
+                f"inverse_kinematics: current_joint_pos needs at least {n} entries, got {current.size}"
+            )
+        q_seed = current[:n]
+        for name, val in zip(self.joint_names, q_seed):
+            self.robot.set_joint(name, float(val))
+
+        self.tip_frame.T_world_frame = desired_ee_pose
+        self.tip_frame.configure(
+            self.target_frame_name, "soft", position_weight, orientation_weight
+        )
+        self.solver.solve(True)
+        self.robot.update_kinematics()
+
+        q_out = np.array(
+            [self.robot.get_joint(name) for name in self.joint_names], dtype=float
+        )
+
+        # Preserve any trailing entries (e.g. gripper) the caller passed in.
+        if current.size > len(self.joint_names):
+            result = current.copy()
+            result[: len(self.joint_names)] = q_out
+            return result
+        return q_out

--- a/lerobot_robot_trlc_dk1/leader.py
+++ b/lerobot_robot_trlc_dk1/leader.py
@@ -34,6 +34,8 @@ class DK1LeaderConfig(TeleoperatorConfig):
     port: str
     gripper_open_pos: int = 2280
     gripper_closed_pos: int = 1670
+    action_read_retries: int = 3
+    action_read_retry_sleep_s: float = 0.01
     
     
 class DK1Leader(Teleoperator):
@@ -107,7 +109,26 @@ class DK1Leader(Teleoperator):
 
         start = time.perf_counter()
         
-        action = self.bus.sync_read(normalize=False, data_name="Present_Position")
+        last_error = None
+        for attempt in range(self.config.action_read_retries):
+            try:
+                action = self.bus.sync_read(normalize=False, data_name="Present_Position")
+                break
+            except ConnectionError as exc:
+                last_error = exc
+                if attempt + 1 >= self.config.action_read_retries:
+                    raise
+                logger.warning(
+                    "%s failed to read leader action (%s/%s): %s",
+                    self,
+                    attempt + 1,
+                    self.config.action_read_retries,
+                    exc,
+                )
+                time.sleep(self.config.action_read_retry_sleep_s)
+        else:
+            raise last_error
+
         action = {f"{motor}.pos": (val/4096*2*np.pi-np.pi) if motor != "gripper" else val for motor, val in action.items()}
         
         # # Normalize gripper position between 1 (closed) and 0 (open)

--- a/lerobot_robot_trlc_dk1/sync_relative_inference.py
+++ b/lerobot_robot_trlc_dk1/sync_relative_inference.py
@@ -1,11 +1,12 @@
-"""A sync inference engine that *does* work with relative-action policies.
+"""A sync inference engine for relative-action policies.
 
-Upstream ``SyncInferenceEngine`` rejects relative-action policies because
-its per-tick flow refreshes ``RelativeActionsProcessorStep._last_state``
-every tick, so cached chunk actions popped on later ticks get re-anchored
-to the *current* robot state — absolute targets drift through the chunk.
+A relative-action policy generates a chunk of actions relative to a single
+reference state, captured in ``RelativeActionsProcessorStep._last_state``.
+If that reference is refreshed every control tick, cached chunk actions
+popped on later ticks get re-anchored to the *current* robot state, so the
+resulting absolute targets drift through the chunk.
 
-This engine sidesteps the issue by:
+This engine avoids that drift by:
 
 1. Calling ``policy.predict_action_chunk(batch)`` (not ``select_action``)
    when the local FIFO is empty.
@@ -25,7 +26,7 @@ This engine sidesteps the issue by:
 Importing this module is enough to (a) register
 ``--inference.type=sync_relative`` with draccus and (b) monkey-patch
 ``lerobot.rollout.inference.factory.create_inference_engine`` to know how
-to build the new engine.
+to build this engine.
 """
 
 from __future__ import annotations
@@ -67,7 +68,7 @@ class SyncRelativeInferenceConfig(InferenceEngineConfig):
 
 
 class SyncRelativeInferenceEngine(InferenceEngine):
-    """Like ``SyncInferenceEngine`` but safe for relative-action policies."""
+    """Synchronous inference engine that is safe for relative-action policies."""
 
     def __init__(
         self,
@@ -127,6 +128,20 @@ class SyncRelativeInferenceEngine(InferenceEngine):
         if obs_frame is None:
             return None
 
+        # Cheap replay: while the FIFO still holds more than the last
+        # (n_obs_steps - 1) precomputed actions, serve them directly — no
+        # preprocessing, no model, no queue update. Running the full
+        # (3-camera) preprocessor on *every* tick adds dispatch jitter, so
+        # only the re-plan neighbourhood pays that cost; serving stays fast
+        # and uniform between chunks. Served actions are unchanged
+        # (precomputed at refill).
+        n_obs = int(getattr(self._policy.config, "n_obs_steps", 1) or 1)
+        if len(self._absolute_chunk) > max(n_obs - 1, 0):
+            return self._pop_ordered()
+
+        # Re-plan neighbourhood: refresh the policy's obs queue (and the
+        # relative step's _last_state) so that at generation the n_obs_steps
+        # history is made of consecutive control ticks, exactly as in training.
         observation = copy(obs_frame)
         autocast_ctx = (
             torch.autocast(device_type=self._device.type)
@@ -137,21 +152,19 @@ class SyncRelativeInferenceEngine(InferenceEngine):
             observation = prepare_observation_for_inference(
                 observation, self._device, self._task, self._robot_type
             )
-            # Always run the preprocessor and policy queue update: this keeps
-            # diffusion's internal obs queue warm with the latest observation
-            # and refreshes the relative step's _last_state to the current
-            # state. The latter only *matters* on chunk-generation ticks —
-            # the postprocessor reads it immediately afterward.
             observation = self._preprocessor(observation)
             batch = self._update_policy_obs_queue(observation)
 
-            if not self._absolute_chunk:
-                self._refill_chunk(batch)
+            if self._absolute_chunk:
+                return self._pop_ordered()
 
-            absolute_action = self._absolute_chunk.popleft()
+            self._refill_chunk(batch)
 
-        action_tensor = absolute_action.squeeze(0).cpu()
-        action_dict = make_robot_action(action_tensor, self._dataset_features)
+        return self._pop_ordered()
+
+    def _pop_ordered(self) -> torch.Tensor:
+        absolute_action = self._absolute_chunk.popleft().squeeze(0).cpu()
+        action_dict = make_robot_action(absolute_action, self._dataset_features)
         return torch.tensor([action_dict[k] for k in self._ordered_action_keys])
 
     # ----- helpers ------------------------------------------------------
@@ -191,10 +204,10 @@ class SyncRelativeInferenceEngine(InferenceEngine):
 
 
 # ---------------------------------------------------------------------------
-# Wire the new engine into ``create_inference_engine`` so build_rollout_context
-# can instantiate it. Upstream ``create_inference_engine`` is a hard-coded
-# if/elif over engine config classes, so we monkey-patch a dispatch shim that
-# handles our subclass first and falls back to the original otherwise.
+# Wire this engine into ``create_inference_engine`` so build_rollout_context
+# can instantiate it. ``create_inference_engine`` dispatches with a hard-coded
+# if/elif over engine config classes, so we monkey-patch a shim that handles
+# our subclass first and falls back to the original otherwise.
 # ---------------------------------------------------------------------------
 
 _original_create_inference_engine = _engine_factory.create_inference_engine

--- a/lerobot_robot_trlc_dk1/sync_relative_inference.py
+++ b/lerobot_robot_trlc_dk1/sync_relative_inference.py
@@ -12,10 +12,10 @@ This engine avoids that drift by:
    when the local FIFO is empty.
 2. Postprocessing **all** ``n_action_steps`` actions in the chunk in one
    go, while the relative step's state cache still reflects the
-   chunk-generation observation. Each chunk's 32 absolute actions are
-   computed against the same reference state — exactly the UMI
-   "relative trajectory" semantics that the model was trained for.
-3. Serving the 32 absolute actions one-per-tick from a local FIFO.
+   chunk-generation observation. Every action in the chunk is therefore
+   converted to absolute against the same reference state — exactly the
+   UMI "relative trajectory" semantics that the model was trained for.
+3. Serving those absolute actions one-per-tick from a local FIFO.
 4. Still running the preprocessor and diffusion observation-queue update
    every tick so the *next* chunk-generation reads a fresh
    ``n_obs_steps`` window. The resulting per-tick state-cache updates
@@ -27,6 +27,19 @@ Importing this module is enough to (a) register
 ``--inference.type=sync_relative`` with draccus and (b) monkey-patch
 ``lerobot.rollout.inference.factory.create_inference_engine`` to know how
 to build this engine.
+
+Usage — import for the side-effect, then select it on the rollout CLI::
+
+    from lerobot_robot_trlc_dk1 import sync_relative_inference  # noqa: F401
+
+    # python examples/ee_rollout.py \\
+    #     --policy.path=<relative-action checkpoint> \\
+    #     --inference.type=sync_relative \\
+    #     --device=cuda --fps=30 --duration=300 --task="..."
+
+The engine requires a ``DiffusionPolicy``-style policy (one exposing
+``_queues`` and ``predict_action_chunk``); other policy types are rejected
+at construction.
 """
 
 from __future__ import annotations
@@ -130,11 +143,11 @@ class SyncRelativeInferenceEngine(InferenceEngine):
 
         # Cheap replay: while the FIFO still holds more than the last
         # (n_obs_steps - 1) precomputed actions, serve them directly — no
-        # preprocessing, no model, no queue update. Running the full
-        # (3-camera) preprocessor on *every* tick adds dispatch jitter, so
-        # only the re-plan neighbourhood pays that cost; serving stays fast
-        # and uniform between chunks. Served actions are unchanged
-        # (precomputed at refill).
+        # preprocessing, no model, no queue update. Running the full image
+        # preprocessor on *every* tick adds dispatch jitter (more so the more
+        # cameras the robot has), so only the re-plan neighbourhood pays that
+        # cost; serving stays fast and uniform between chunks. Served actions
+        # are unchanged (precomputed at refill).
         n_obs = int(getattr(self._policy.config, "n_obs_steps", 1) or 1)
         if len(self._absolute_chunk) > max(n_obs - 1, 0):
             return self._pop_ordered()

--- a/lerobot_robot_trlc_dk1/sync_relative_inference.py
+++ b/lerobot_robot_trlc_dk1/sync_relative_inference.py
@@ -1,0 +1,262 @@
+"""A sync inference engine that *does* work with relative-action policies.
+
+Upstream ``SyncInferenceEngine`` rejects relative-action policies because
+its per-tick flow refreshes ``RelativeActionsProcessorStep._last_state``
+every tick, so cached chunk actions popped on later ticks get re-anchored
+to the *current* robot state — absolute targets drift through the chunk.
+
+This engine sidesteps the issue by:
+
+1. Calling ``policy.predict_action_chunk(batch)`` (not ``select_action``)
+   when the local FIFO is empty.
+2. Postprocessing **all** ``n_action_steps`` actions in the chunk in one
+   go, while the relative step's state cache still reflects the
+   chunk-generation observation. Each chunk's 32 absolute actions are
+   computed against the same reference state — exactly the UMI
+   "relative trajectory" semantics that the model was trained for.
+3. Serving the 32 absolute actions one-per-tick from a local FIFO.
+4. Still running the preprocessor and diffusion observation-queue update
+   every tick so the *next* chunk-generation reads a fresh
+   ``n_obs_steps`` window. The resulting per-tick state-cache updates
+   are harmless: only generation ticks read the cache (through the
+   postprocessor loop), and they read it immediately after preprocessing
+   the current frame.
+
+Importing this module is enough to (a) register
+``--inference.type=sync_relative`` with draccus and (b) monkey-patch
+``lerobot.rollout.inference.factory.create_inference_engine`` to know how
+to build the new engine.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from contextlib import nullcontext
+from copy import copy
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from lerobot.policies.pretrained import PreTrainedPolicy
+from lerobot.policies.utils import (
+    make_robot_action,
+    populate_queues,
+    prepare_observation_for_inference,
+)
+from lerobot.processor import PolicyProcessorPipeline
+from lerobot.rollout.inference import factory as _engine_factory
+from lerobot.rollout.inference.base import InferenceEngine
+from lerobot.rollout.inference.factory import InferenceEngineConfig
+from lerobot.utils.constants import ACTION, OBS_IMAGES
+
+logger = logging.getLogger(__name__)
+
+
+@InferenceEngineConfig.register_subclass("sync_relative")
+@dataclass
+class SyncRelativeInferenceConfig(InferenceEngineConfig):
+    """Inline synchronous inference for relative-action policies.
+
+    Generates the full action chunk via ``predict_action_chunk``,
+    postprocesses all actions against the chunk-time state, then serves
+    them one-per-tick. Equivalent to UMI's relative-trajectory rollout.
+    """
+
+
+class SyncRelativeInferenceEngine(InferenceEngine):
+    """Like ``SyncInferenceEngine`` but safe for relative-action policies."""
+
+    def __init__(
+        self,
+        policy: PreTrainedPolicy,
+        preprocessor: PolicyProcessorPipeline,
+        postprocessor: PolicyProcessorPipeline,
+        dataset_features: dict,
+        ordered_action_keys: list[str],
+        task: str,
+        device: str | None,
+        robot_type: str,
+    ) -> None:
+        # _update_policy_obs_queue mirrors DiffusionPolicy's queue plumbing
+        # (`_queues` + `predict_action_chunk`); other policies (e.g. ACT with
+        # its `_action_queue`) would fail silently mid-rollout, so reject them
+        # up front.
+        if not hasattr(policy, "_queues") or not callable(
+            getattr(policy, "predict_action_chunk", None)
+        ):
+            raise TypeError(
+                f"sync_relative requires a DiffusionPolicy-style policy with "
+                f"`_queues` and `predict_action_chunk`; got {type(policy).__name__}."
+            )
+        self._policy = policy
+        self._preprocessor = preprocessor
+        self._postprocessor = postprocessor
+        self._dataset_features = dataset_features
+        self._ordered_action_keys = ordered_action_keys
+        self._task = task
+        self._device = torch.device(device or "cpu")
+        self._robot_type = robot_type
+        self._absolute_chunk: deque[torch.Tensor] = deque()
+        logger.info(
+            "SyncRelativeInferenceEngine initialized (device=%s, action_keys=%d, "
+            "n_action_steps=%d)",
+            self._device,
+            len(ordered_action_keys),
+            int(getattr(policy.config, "n_action_steps", 0)),
+        )
+
+    # ----- lifecycle ----------------------------------------------------
+    def start(self) -> None:
+        logger.info("SyncRelativeInferenceEngine started")
+
+    def stop(self) -> None:
+        logger.info("SyncRelativeInferenceEngine stopped")
+
+    def reset(self) -> None:
+        logger.info("Resetting sync_relative inference state (policy + processors + FIFO)")
+        self._policy.reset()
+        self._preprocessor.reset()
+        self._postprocessor.reset()
+        self._absolute_chunk.clear()
+
+    # ----- per-tick action production -----------------------------------
+    def get_action(self, obs_frame: dict | None) -> torch.Tensor | None:
+        if obs_frame is None:
+            return None
+
+        observation = copy(obs_frame)
+        autocast_ctx = (
+            torch.autocast(device_type=self._device.type)
+            if self._device.type == "cuda" and self._policy.config.use_amp
+            else nullcontext()
+        )
+        with torch.inference_mode(), autocast_ctx:
+            observation = prepare_observation_for_inference(
+                observation, self._device, self._task, self._robot_type
+            )
+            # Always run the preprocessor and policy queue update: this keeps
+            # diffusion's internal obs queue warm with the latest observation
+            # and refreshes the relative step's _last_state to the current
+            # state. The latter only *matters* on chunk-generation ticks —
+            # the postprocessor reads it immediately afterward.
+            observation = self._preprocessor(observation)
+            batch = self._update_policy_obs_queue(observation)
+
+            if not self._absolute_chunk:
+                self._refill_chunk(batch)
+
+            absolute_action = self._absolute_chunk.popleft()
+
+        action_tensor = absolute_action.squeeze(0).cpu()
+        action_dict = make_robot_action(action_tensor, self._dataset_features)
+        return torch.tensor([action_dict[k] for k in self._ordered_action_keys])
+
+    # ----- helpers ------------------------------------------------------
+    def _update_policy_obs_queue(self, observation: dict[str, Any]) -> dict[str, Any]:
+        # Mirror ``DiffusionPolicy.select_action``'s queue plumbing: pop ACTION
+        # from the input, stack camera streams into ``observation.images`` if
+        # the policy uses separate encoders, then populate the policy's obs
+        # queues so ``predict_action_chunk`` can stack history along dim=1.
+        batch = dict(observation)
+        if ACTION in batch:
+            batch.pop(ACTION)
+        if getattr(self._policy.config, "image_features", None):
+            batch[OBS_IMAGES] = torch.stack(
+                [batch[k] for k in self._policy.config.image_features], dim=-4
+            )
+        self._policy._queues = populate_queues(self._policy._queues, batch)
+        return batch
+
+    def _refill_chunk(self, batch: dict[str, Any]) -> None:
+        """Generate a fresh chunk and store its absolute actions in the FIFO."""
+        start = time.perf_counter()
+        # Relative chunk shaped (B, n_action_steps, action_dim).
+        action_chunk = self._policy.predict_action_chunk(batch)
+
+        # Convert every action in the chunk to absolute using the SAME
+        # state cache (the one captured by the preprocessor a moment ago).
+        for t in range(action_chunk.shape[1]):
+            relative_action = action_chunk[:, t, :]
+            absolute_action = self._postprocessor(relative_action)
+            self._absolute_chunk.append(absolute_action)
+
+        logger.info(
+            "sync_relative chunk refill: %d actions in %.2fs",
+            action_chunk.shape[1],
+            time.perf_counter() - start,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wire the new engine into ``create_inference_engine`` so build_rollout_context
+# can instantiate it. Upstream ``create_inference_engine`` is a hard-coded
+# if/elif over engine config classes, so we monkey-patch a dispatch shim that
+# handles our subclass first and falls back to the original otherwise.
+# ---------------------------------------------------------------------------
+
+_original_create_inference_engine = _engine_factory.create_inference_engine
+
+
+def _create_inference_engine_with_relative(
+    config: InferenceEngineConfig,
+    *,
+    policy: PreTrainedPolicy,
+    preprocessor: PolicyProcessorPipeline,
+    postprocessor: PolicyProcessorPipeline,
+    robot_wrapper,  # ThreadSafeRobot, untyped to avoid the import.
+    hw_features: dict,
+    dataset_features: dict,
+    ordered_action_keys: list[str],
+    task: str,
+    fps: float,
+    device: str | None,
+    use_torch_compile: bool = False,
+    compile_warmup_inferences: int = 2,
+    shutdown_event=None,
+):
+    if isinstance(config, SyncRelativeInferenceConfig):
+        logger.info("Creating inference engine: sync_relative")
+        return SyncRelativeInferenceEngine(
+            policy=policy,
+            preprocessor=preprocessor,
+            postprocessor=postprocessor,
+            dataset_features=dataset_features,
+            ordered_action_keys=ordered_action_keys,
+            task=task,
+            device=device,
+            robot_type=robot_wrapper.robot_type,
+        )
+    return _original_create_inference_engine(
+        config,
+        policy=policy,
+        preprocessor=preprocessor,
+        postprocessor=postprocessor,
+        robot_wrapper=robot_wrapper,
+        hw_features=hw_features,
+        dataset_features=dataset_features,
+        ordered_action_keys=ordered_action_keys,
+        task=task,
+        fps=fps,
+        device=device,
+        use_torch_compile=use_torch_compile,
+        compile_warmup_inferences=compile_warmup_inferences,
+        shutdown_event=shutdown_event,
+    )
+
+
+_engine_factory.create_inference_engine = _create_inference_engine_with_relative
+# Also patch the re-export used by ``build_rollout_context`` if it imported
+# the symbol directly.
+try:
+    from lerobot.rollout import context as _rollout_context  # noqa: WPS433
+
+    if hasattr(_rollout_context, "create_inference_engine"):
+        _rollout_context.create_inference_engine = _create_inference_engine_with_relative
+except ImportError:
+    pass
+
+
+__all__ = ["SyncRelativeInferenceConfig", "SyncRelativeInferenceEngine"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "numpy>=2.0.1",
   "pyserial>=3.5",
   "dynamixel-sdk>=3.7.31",
-  "lerobot[dynamixel,viz]>= 0.5.1",
+  "lerobot[dynamixel,viz,kinematics]>= 0.5.1",
   "mujoco>=3.0.0",
 ]
 

--- a/trlc_dk1_control/motor_chain.py
+++ b/trlc_dk1_control/motor_chain.py
@@ -84,6 +84,7 @@ class DK1MotorChain:
 
         self._running = False
         self._thread: threading.Thread | None = None
+        self._thread_error: BaseException | None = None
 
         # Performance tracking
         self._loop_count = 0
@@ -164,7 +165,12 @@ class DK1MotorChain:
 
     @property
     def is_running(self) -> bool:
-        return self._running
+        return self._running and self._thread_error is None
+
+    def raise_if_failed(self) -> None:
+        """Raise if the background motor thread has failed."""
+        if self._thread_error is not None:
+            raise RuntimeError("DK1MotorChain motor thread failed") from self._thread_error
 
     # -------------------------------------------------------------------------
     # Setup
@@ -255,79 +261,84 @@ class DK1MotorChain:
         period = 1.0 / self._config.motor_thread_hz
         arm_names = [f"joint_{i}" for i in range(1, 7)]
 
-        while self._running:
-            t_start = time.monotonic()
+        try:
+            while self._running:
+                t_start = time.monotonic()
 
-            # Snapshot commands under lock
-            with self._lock:
-                kp = self._arm_kp.copy()
-                kd = self._arm_kd.copy()
-                q_des = self._arm_q_des.copy()
-                dq_des = self._arm_dq_des.copy()
-                tau_ff = self._arm_tau_ff.copy()
-                g_q_des = self._gripper_q_des
-                g_vel = self._gripper_vel
-                g_i_des = self._gripper_i_des
+                # Snapshot commands under lock
+                with self._lock:
+                    kp = self._arm_kp.copy()
+                    kd = self._arm_kd.copy()
+                    q_des = self._arm_q_des.copy()
+                    dq_des = self._arm_dq_des.copy()
+                    tau_ff = self._arm_tau_ff.copy()
+                    g_q_des = self._gripper_q_des
+                    g_vel = self._gripper_vel
+                    g_i_des = self._gripper_i_des
 
-            # Send MIT commands to arm joints and read feedback
-            for i, name in enumerate(arm_names):
-                motor = self._motors[name]
-                self._control.controlMIT(
-                    motor,
-                    float(kp[i]),
-                    float(kd[i]),
-                    float(q_des[i]),
-                    float(dq_des[i]),
-                    float(tau_ff[i]),
+                # Send MIT commands to arm joints and read feedback
+                for i, name in enumerate(arm_names):
+                    motor = self._motors[name]
+                    self._control.controlMIT(
+                        motor,
+                        float(kp[i]),
+                        float(kd[i]),
+                        float(q_des[i]),
+                        float(dq_des[i]),
+                        float(tau_ff[i]),
+                    )
+
+                # Send EMIT command to gripper
+                self._control.control_pos_force(
+                    self._motors["gripper"],
+                    float(g_q_des),
+                    float(g_vel),
+                    float(g_i_des),
                 )
 
-            # Send EMIT command to gripper
-            self._control.control_pos_force(
-                self._motors["gripper"],
-                float(g_q_des),
-                float(g_vel),
-                float(g_i_des),
-            )
+                # Collect motor state (updated by recv() inside each control call)
+                new_pos = np.empty(7)
+                new_vel = np.empty(7)
+                new_torque = np.empty(7)
+                for i, name in enumerate(arm_names):
+                    m = self._motors[name]
+                    new_pos[i] = m.getPosition()
+                    new_vel[i] = m.getVelocity()
+                    new_torque[i] = m.getTorque()
+                gm = self._motors["gripper"]
+                new_pos[6] = gm.getPosition()
+                new_vel[6] = gm.getVelocity()
+                new_torque[6] = gm.getTorque()
 
-            # Collect motor state (updated by recv() inside each control call)
-            new_pos = np.empty(7)
-            new_vel = np.empty(7)
-            new_torque = np.empty(7)
-            for i, name in enumerate(arm_names):
-                m = self._motors[name]
-                new_pos[i] = m.getPosition()
-                new_vel[i] = m.getVelocity()
-                new_torque[i] = m.getTorque()
-            gm = self._motors["gripper"]
-            new_pos[6] = gm.getPosition()
-            new_vel[6] = gm.getVelocity()
-            new_torque[6] = gm.getTorque()
+                # Update shared state buffer
+                with self._lock:
+                    self._pos = new_pos
+                    self._vel = new_vel
+                    self._torque = new_torque
 
-            # Update shared state buffer
-            with self._lock:
-                self._pos = new_pos
-                self._vel = new_vel
-                self._torque = new_torque
+                # Maintain loop period — sleep most of the time, busywait the tail
+                # for precision (time.sleep has ~1-2 ms granularity on macOS)
+                elapsed = time.monotonic() - t_start
+                sleep_time = period - elapsed
+                if sleep_time > 0.001:
+                    time.sleep(sleep_time - 0.001)
+                while time.monotonic() - t_start < period:
+                    pass
 
-            # Maintain loop period — sleep most of the time, busywait the tail
-            # for precision (time.sleep has ~1-2 ms granularity on macOS)
-            elapsed = time.monotonic() - t_start
-            sleep_time = period - elapsed
-            if sleep_time > 0.001:
-                time.sleep(sleep_time - 0.001)
-            while time.monotonic() - t_start < period:
-                pass
-
-            # Periodic performance print
-            self._loop_count += 1
-            now = time.monotonic()
-            if now - self._last_perf_log >= 5.0:
-                hz = self._loop_count / (now - self._last_perf_log)
-                logger.debug(
-                    "[motor]  %6.1f Hz  (target %.0f Hz)  loop=%.2f ms",
-                    hz,
-                    self._config.motor_thread_hz,
-                    elapsed * 1e3,
-                )
-                self._loop_count = 0
-                self._last_perf_log = now
+                # Periodic performance print
+                self._loop_count += 1
+                now = time.monotonic()
+                if now - self._last_perf_log >= 5.0:
+                    hz = self._loop_count / (now - self._last_perf_log)
+                    logger.debug(
+                        "[motor]  %6.1f Hz  (target %.0f Hz)  loop=%.2f ms",
+                        hz,
+                        self._config.motor_thread_hz,
+                        elapsed * 1e3,
+                    )
+                    self._loop_count = 0
+                    self._last_perf_log = now
+        except BaseException as exc:
+            self._thread_error = exc
+            self._running = False
+            logger.exception("DK1MotorChain motor thread failed")

--- a/trlc_dk1_control/robot.py
+++ b/trlc_dk1_control/robot.py
@@ -120,6 +120,7 @@ class DK1Robot:
         Args:
             q_des: Target positions in radians, shape (6,).
         """
+        self._motor_chain.raise_if_failed()
         if q_des.shape != (6,):
             raise ValueError(f"Expected shape (6,), got {q_des.shape}")
         with self._cmd_lock:
@@ -135,6 +136,7 @@ class DK1Robot:
         Args:
             normalized_pos: 0.0 = fully open, 1.0 = fully closed.
         """
+        self._motor_chain.raise_if_failed()
         normalized_pos = float(np.clip(normalized_pos, 0.0, 1.0))
         with self._cmd_lock:
             self._gripper_des = normalized_pos
@@ -150,6 +152,7 @@ class DK1Robot:
         Returns:
             dict with keys 'pos', 'vel', 'torque', each shape (6,).
         """
+        self._motor_chain.raise_if_failed()
         pos, vel, torque = self._motor_chain.get_state()
         return {
             "pos": pos[:6].copy(),
@@ -159,6 +162,7 @@ class DK1Robot:
 
     def get_gripper_state(self) -> dict[str, float]:
         """Return normalised gripper position and torque."""
+        self._motor_chain.raise_if_failed()
         pos, _, torque = self._motor_chain.get_state()
         cfg = self._config
         # Linear map open->0, closed->1.  np.interp can't be used here because it

--- a/urdf/follower/TRLC-DK1-Follower.urdf
+++ b/urdf/follower/TRLC-DK1-Follower.urdf
@@ -3,16 +3,16 @@
   name="TRLC-DK1-Follower">
   <!--
   Joint limits:
-    - joint1: -2.094 to 2.094 (±120°)
-    - joint2: -0.08 to 3.14
-    - joint3: -0.08 to 4.71  (DM4340)
-    - joint4: -1.95 to 1.57 (-111.7° to +90°)
-    - joint5: -1.57 to 1.57 (±90°)
-    - joint6: -3.14 to 3.14 (±180°)
+    - joint_1: -2.094 to 2.094 (±120°)
+    - joint_2: -0.08 to 3.14
+    - joint_3: -0.08 to 4.71  (DM4340)
+    - joint_4: -1.95 to 1.57 (-111.7° to +90°)
+    - joint_5: -1.57 to 1.57 (±90°)
+    - joint_6: -2.094 to 2.094 (±120°)
   
   Joint motors:
-    - joint{1,2,3}: DAMIAO Motor DM4340, 52.5 rpm, 5.49 rad/s
-    - joint{4,5,6}: DAMIAO Motor DM4310, 200 rpm, 20.94 rad/s
+    - joint_{1,2,3}: DAMIAO Motor DM4340, 52.5 rpm, 5.49 rad/s
+    - joint_{4,5,6}: DAMIAO Motor DM4310, 200 rpm, 20.94 rad/s
     - gripper DAMIAO Motor DM4310, 0.00875m spur gear radius, 0.183225 m/s, 114N
   -->
   <link
@@ -68,7 +68,7 @@
     </collision>
   </link>
   <joint
-    name="joint1"
+    name="joint_1"
     type="revolute">
     <origin
       xyz="0 0 0.0615"
@@ -112,7 +112,7 @@
     </collision>
   </link>
   <joint
-    name="joint2"
+    name="joint_2"
     type="revolute">
     <origin
       xyz="0.02 0.0 0.0385"
@@ -156,7 +156,7 @@
     </collision>
   </link>
   <joint
-    name="joint3"
+    name="joint_3"
     type="revolute">
     <origin
       xyz="-0.264 0 0"
@@ -200,7 +200,7 @@
     </collision>
   </link>
   <joint
-    name="joint4"
+    name="joint_4"
     type="revolute">
     <origin
       xyz="0.244004 0 0.059971"
@@ -244,7 +244,7 @@
     </collision>
   </link>
   <joint
-    name="joint5"
+    name="joint_5"
     type="revolute">
     <origin
       xyz="0.061868 0 0.0425"
@@ -288,7 +288,7 @@
     </collision>
   </link>
   <joint
-    name="joint6"
+    name="joint_6"
     type="revolute">
     <origin
       xyz="0.032 0 -0.0425"


### PR DESCRIPTION
## Summary

Adds an end-effector (Cartesian) control pipeline for the DK1 on top of the existing impedance stack: leader→follower teleop, dataset recording, and policy rollout all operate in EE space (FK on leader/observation, IK on the action), so datasets store Cartesian columns and policies are trained/run in task space.

## What's included

- **EE pipeline builders** (`ee_pipelines.py`) — FK on leader joints and follower observations, IK on the action, with optional `EEBoundsAndSafety` and per-tick IK convergence.
- **`DK1RobotKinematics`** (`kinematics.py`) — radian-I/O shim over LeRobot's placo-backed `RobotKinematics`, with singularity damping via kinetic-energy regularization and an optional `converge_ik` mode that iterates the differential solver to tolerance instead of taking a single step.
- **Examples** — `ee_teleop.py`, `ee_record.py`, `ee_rollout.py`, each wrapping the standard LeRobot scripts so all their CLI flags work unchanged.
- **`SyncRelativeInferenceEngine`** (`sync_relative_inference.py`) — a synchronous inference engine for relative-action (UMI-style) policies, registered as `--inference.type=sync_relative`.
- **Robustness** — follower connect/disconnect cleanup on partial failure; motor-thread failures now surface through `DK1Robot` instead of silently serving stale state; leader read retries on transient `ConnectionError`.

## Inference engine note

The stock `SyncInferenceEngine` rejects relative-action policies: its per-tick flow re-anchors cached chunk actions to the *current* robot state, so absolute targets drift through a chunk. `SyncRelativeInferenceEngine` instead generates the full chunk via `predict_action_chunk`, converts every action to absolute against the single chunk-time state, and serves them from a FIFO (with a cheap-replay fast path between re-plans). It is wired in by monkey-patching `create_inference_engine`, since upstream's factory is a hard-coded if/elif — activated by the side-effect import in `ee_rollout.py`. It targets DiffusionPolicy-style policies and rejects others with a clear error.

## ⚠️ Breaking change

`urdf/follower/TRLC-DK1-Follower.urdf` joint names are renamed `joint1`→`joint_1` … `joint6`→`joint_6` to match the motor/observation keys used throughout the package (placo addresses joints by name). Anything else consuming this URDF by the old joint names will need updating.

## Notes

- IK seeds from the measured joints by default (`initial_guess_current_joints=True`): seeding from the previous commanded solution caused the follower to swing under compliant impedance control (observed on hardware), and measured-joint seeding matches how the datasets were collected.
- Builds on the recently merged impedance controller; no changes to the impedance control logic itself.
